### PR TITLE
Add defaultACL option to route() for per-route ACL selection

### DIFF
--- a/apps/docs/content/docs/routes-multiple.mdx
+++ b/apps/docs/content/docs/routes-multiple.mdx
@@ -68,6 +68,12 @@ Multiple file routes have the following options:
       type: 'object',
       required: false,
     },
+    defaultACL: {
+      description:
+        'The default ACL to use for the uploaded files.',
+      type: 'string',
+      required: false,
+    },
   }}
 />
 

--- a/apps/docs/content/docs/routes-single.mdx
+++ b/apps/docs/content/docs/routes-single.mdx
@@ -61,6 +61,12 @@ Single file routes have the following options:
       type: 'object',
       required: false,
     },
+    defaultACL: {
+      description:
+        'The default ACL to use for the uploaded files.',
+      type: 'string',
+      required: false,
+    },
   }}
 />
 

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/example/next-env.d.ts
+++ b/apps/example/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/better-upload/src/client/utils/internal/s3-upload.ts
+++ b/packages/better-upload/src/client/utils/internal/s3-upload.ts
@@ -44,6 +44,10 @@ export async function uploadFileToS3(params: {
         xhr.open('PUT', params.signedUrl, true);
         xhr.setRequestHeader('Content-Type', params.file.type);
 
+        const signedUrl = new URL(params.signedUrl);
+        const xAmzAcl = signedUrl.searchParams.get('x-amz-acl');
+        if (xAmzAcl) xhr.setRequestHeader('x-amz-acl', xAmzAcl);
+
         Object.entries(params.objectMetadata).forEach(([key, value]) => {
           xhr.setRequestHeader(`x-amz-meta-${key}`, value);
         });

--- a/packages/better-upload/src/server/router/handlers/files-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/files-handler.ts
@@ -133,6 +133,7 @@ export async function handleFiles({
           ContentType: file.type,
           ContentLength: file.size,
           Metadata: objectMetadata,
+          ACL: route.defaultACL,
         }),
         {
           expiresIn: signedUrlExpiresIn,

--- a/packages/better-upload/src/server/router/handlers/multipart-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/multipart-handler.ts
@@ -129,6 +129,7 @@ export async function handleMultipartFiles({
           Key: objectKey,
           ContentType: file.type,
           Metadata: objectMetadata,
+          ACL: route.defaultACL,
         })
       );
 

--- a/packages/better-upload/src/server/types/internal.ts
+++ b/packages/better-upload/src/server/types/internal.ts
@@ -1,10 +1,13 @@
 import type { StandardSchemaV1 } from './standard-schema';
+import type { ObjectCannedACL } from '@aws-sdk/client-s3';
 
 export type UnknownMetadata = Record<string, unknown>;
 export type ObjectMetadata = Record<string, string>;
 
 type ClientMetadata<T extends StandardSchemaV1 | undefined = undefined> =
   T extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<T> : unknown;
+
+type DefaultACL = ObjectCannedACL | undefined;
 
 export type FileInfo = {
   /**
@@ -33,6 +36,7 @@ export type RouteConfig<
   Multipart extends boolean,
   InterMetadata extends UnknownMetadata,
   ClientMetadataSchema extends StandardSchemaV1 | undefined,
+  DefaultACL extends ObjectCannedACL | undefined,
 > = {
   /**
    * Maximum file size in bytes.
@@ -170,6 +174,11 @@ export type RouteConfig<
     | AfterSignedUrlCallbackResult
     | void
     | Promise<AfterSignedUrlCallbackResult | void>;
+
+  /**
+   * The default ACL to use for the uploaded files.
+   */
+  defaultACL?: DefaultACL;
 } & (Multiple extends true
   ? {
       /**
@@ -313,6 +322,8 @@ export type Route = {
     partSignedUrlExpiresIn?: number;
     completeSignedUrlExpiresIn?: number;
   };
+
+  defaultACL?: DefaultACL;
 
   onBeforeUpload?: (data: {
     req: Request;

--- a/packages/better-upload/src/server/utils/router.ts
+++ b/packages/better-upload/src/server/utils/router.ts
@@ -1,3 +1,4 @@
+import type { ObjectCannedACL } from '@aws-sdk/client-s3';
 import type {
   ExecRoute,
   ObjectMetadata,
@@ -12,14 +13,22 @@ export function route<
   Multipart extends boolean = false,
   InterMetadata extends UnknownMetadata = {},
   ClientMetadataSchema extends StandardSchemaV1 | undefined = undefined,
+  DefaultACL extends ObjectCannedACL | undefined = undefined,
 >(
-  config: RouteConfig<Multiple, Multipart, InterMetadata, ClientMetadataSchema>
+  config: RouteConfig<
+    Multiple,
+    Multipart,
+    InterMetadata,
+    ClientMetadataSchema,
+    DefaultACL
+  >
 ): ExecRoute {
   const route: Route = {
     maxFileSize: config.maxFileSize,
     fileTypes: config.fileTypes,
     signedUrlExpiresIn: config.signedUrlExpiresIn,
     clientMetadataSchema: config.clientMetadataSchema,
+    defaultACL: config.defaultACL,
 
     maxFiles: config.multipleFiles ? config.maxFiles : 1,
 


### PR DESCRIPTION
# Add `defaultACL` option to `route()` for per-route ACL selection

## Summary
This PR introduces a new optional parameter, `defaultACL`, to the `route()` helper. It lets users choose the access control list (ACL) to apply **per route** (e.g., `public-read`, `private`), or omit it entirely to keep the current behavior.

## Motivation
- Different endpoints often need different visibility settings (e.g., public images vs. private documents).
- On providers like **DigitalOcean Spaces**, it’s not straightforward to make an entire bucket `public-read`. Being able to set an ACL at the route level is much more practical.
- Naming it **`defaultACL`** leaves room for future enhancements (e.g., per-file ACL decisions at runtime), where this value can be overridden.

## What’s changed
- Added support for `defaultACL?: string` in `route()`.
- Updated documentation to include this new parameter.
- If provided, uploads handled by that route will use the given ACL by default.
- If omitted, behavior is unchanged (no ACL forced).

## Usage
```ts
// better-upload config example
export default defineConfig({
  routes: {
    image: route({
      fileTypes: ['image/*'],
      maxFileSize: 1024 * 1024 * 2, // 2MB
      defaultACL: 'public-read',
    }),
  },
});
```

## Backward compatibility
- Fully backward compatible. Existing code that doesn’t pass `defaultACL` continues to work exactly as before.

## Testing
- I implemented and tested this change locally in a real project. It works perfectly for my use case (including uploads to DigitalOcean Spaces with `public-read`).

## Notes
- This design purposefully uses **“default”** in `defaultACL` to make it easy to extend later with a per-file override (e.g., a callback that decides ACL dynamically) without breaking the API.
