### PR TITLE
Version 2.0.0

### DIFF
--- a/.changeset/ripe-zoos-cover.md
+++ b/.changeset/ripe-zoos-cover.md
@@ -1,0 +1,9 @@
+---
+'better-upload': major
+---
+
+Version 2.0.0
+
+## Breaking Changes
+
+suggest new properties by opening an issue

--- a/.changeset/ripe-zoos-cover.md
+++ b/.changeset/ripe-zoos-cover.md
@@ -4,6 +4,47 @@
 
 Version 2.0.0
 
+This update changes how properties of the S3 object are set when uploading files, making it more flexible. It also includes some changes for better usability.
+
 ## Breaking Changes
 
-suggest new properties by opening an issue
+### `onBeforeUpload` return
+
+You now return `objectInfo` (`generateObjectInfo` for multiple files) instead of `objectKey` (`generateObjectKey` for multiple files) and `objectMetadata` (`generateObjectMetadata` for multiple files).
+
+Example:
+
+```ts
+// single files
+route({
+  onBeforeUpload: ({ file }) => {
+    return {
+      objectInfo: {
+        key: `uploads/${file.name}`,
+      },
+    };
+  },
+});
+
+// multiple files
+route({
+  multipleFiles: true,
+  onBeforeUpload: () => {
+    return {
+      generateObjectInfo: ({ file }) => ({
+        key: `uploads/${file.name}`,
+      }),
+    };
+  },
+});
+```
+
+With this change, you can now also set other properties of the S3 object, like `acl` and `storageClass`. Please suggest new properties by opening an issue.
+
+### `UploadFileError` to reject upload has been renamed
+
+To reject an upload in `onBeforeUpload`, you now throw `RejectUpload` instead of throwing `UploadFileError`.
+
+### Cloudflare R2 helper renamed
+
+The `r2` helper client for Cloudflare R2 has been renamed to `cloudflare`. This is to make it more consistent with other helpers.

--- a/.changeset/witty-owls-follow.md
+++ b/.changeset/witty-owls-follow.md
@@ -1,0 +1,5 @@
+---
+'better-upload': minor
+---
+
+Rename `r2` client helper to `cloudflare`

--- a/apps/docs/content/docs/guides/form.mdx
+++ b/apps/docs/content/docs/guides/form.mdx
@@ -53,7 +53,7 @@ const router: Router = {
       maxFiles: 5,
       onBeforeUpload() {
         return {
-          generateObjectKey: ({ file }) => `form/${file.name}`,
+          generateObjectInfo: ({ file }) => ({ key: `form/${file.name}` }),
         };
       },
     }),

--- a/apps/docs/content/docs/helpers-server.mdx
+++ b/apps/docs/content/docs/helpers-server.mdx
@@ -24,15 +24,15 @@ icon: Wrench
 Better Upload has some built-in clients for popular S3-compatible storage services, like Cloudflare R2. Suggest a new client by [opening an issue](https://github.com/Nic13Gamer/better-upload/issues).
 
 ```ts tab="Cloudflare R2"
-import { r2 } from 'better-upload/server/helpers';
+import { cloudflare } from 'better-upload/server/helpers';
 
-const client = r2({
+const client = cloudflare({
   accountId: 'your-account-id',
   accessKeyId: 'your-access-key-id',
   secretAccessKey: 'your-secret-access-key',
 });
 
-const jurisdictionClient = r2({
+const jurisdictionClient = cloudflare({
   accountId: 'your-account-id',
   accessKeyId: 'your-access-key-id',
   secretAccessKey: 'your-secret-access-key',
@@ -106,7 +106,7 @@ Moves an object from one location to another, within the same bucket. Also known
 import { moveObject } from 'better-upload/server/helpers';
 
 await moveObject({
-  client: r2(),
+  client: s3,
   bucketName: 'my-bucket',
   objectKey: 'example.jpg',
   destinationKey: 'images/example.jpg',

--- a/apps/docs/content/docs/quickstart-single.mdx
+++ b/apps/docs/content/docs/quickstart-single.mdx
@@ -145,7 +145,7 @@ In the example above, we create the upload route `demo`. Learn more about upload
 You can run code before uploads in the server. Use the `onBeforeUpload` callback:
 
 ```ts
-import { UploadFileError, route, type Router } from 'better-upload/server';
+import { RejectUpload, route, type Router } from 'better-upload/server';
 
 const auth = (req: Request) => ({ id: 'fake-user-id' }); // [!code highlight]
 
@@ -160,7 +160,7 @@ const router: Router = {
         const user = await auth(req);
 
         if (!user) {
-          throw new UploadFileError('Not logged in!');
+          throw new RejectUpload('Not logged in!');
         }
       },
     }),

--- a/apps/docs/content/docs/quickstart-single.mdx
+++ b/apps/docs/content/docs/quickstart-single.mdx
@@ -180,10 +180,12 @@ const router: Router = {
   routes: {
     demo: route({
       fileTypes: ['image/*'],
-      // [!code ++:5]
+      // [!code ++:7]
       onBeforeUpload: async ({ req, file, clientMetadata }) => {
         return {
-          objectKey: `files/${file.name}`,
+          objectInfo: {
+            key: `files/${file.name}`,
+          },
         };
       },
     }),

--- a/apps/docs/content/docs/quickstart.mdx
+++ b/apps/docs/content/docs/quickstart.mdx
@@ -192,10 +192,12 @@ const router: Router = {
       fileTypes: ['image/*'],
       multipleFiles: true,
       maxFiles: 4,
-      // [!code ++:5]
+      // [!code ++:7]
       onBeforeUpload: async ({ req, files, clientMetadata }) => {
         return {
-          generateObjectKey: ({ file }) => `files/${file.name}`,
+          generateObjectInfo: ({ file }) => ({
+            key: `files/${file.name}`,
+          }),
         };
       },
     }),

--- a/apps/docs/content/docs/quickstart.mdx
+++ b/apps/docs/content/docs/quickstart.mdx
@@ -153,7 +153,7 @@ In the example above, we create the upload route `demo`. Learn more about upload
 You can run code before uploads in the server. Use the `onBeforeUpload` callback:
 
 ```ts
-import { UploadFileError, route, type Router } from 'better-upload/server';
+import { RejectUpload, route, type Router } from 'better-upload/server';
 
 const auth = (req: Request) => ({ id: 'fake-user-id' }); // [!code highlight]
 
@@ -170,7 +170,7 @@ const router: Router = {
         const user = await auth(req);
 
         if (!user) {
-          throw new UploadFileError('Not logged in!');
+          throw new RejectUpload('Not logged in!');
         }
       },
     }),

--- a/apps/docs/content/docs/routes-multiple.mdx
+++ b/apps/docs/content/docs/routes-multiple.mdx
@@ -91,7 +91,9 @@ route({
     }
 
     return {
-      generateObjectKey: ({ file }) => `${user.id}/${file.name}`,
+      generateObjectInfo: ({ file }) => ({
+        key: `${user.id}/${file.name}`,
+      }),
       bucketName: 'another-bucket',
     };
   },
@@ -107,16 +109,16 @@ You can return an object with the following properties:
 
 <TypeTable
   type={{
-    generateObjectKey: {
+    generateObjectInfo: {
       description:
-        'The S3 object key. If not provided, a random key will be generated.',
-      type: '() => string',
-      required: false,
-    },
-    generateObjectMetadata: {
-      description:
-        'Metadata to be added to the S3 object. This data will be exposed to the client.',
-      type: '() => Record<string, string>',
+        'Information about the S3 object. Includes the object key, metadata, ACL, and other properties.',
+      type: '() => object',
+      typeDescription: (
+        <>
+          Includes: <code>key</code>, <code>metadata</code>, <code>acl</code>,{' '}
+          <code>storageClass</code>.
+        </>
+      ),
       required: false,
     },
     metadata: {

--- a/apps/docs/content/docs/routes-multiple.mdx
+++ b/apps/docs/content/docs/routes-multiple.mdx
@@ -87,7 +87,7 @@ route({
     const user = await auth();
 
     if (!user) {
-      throw new UploadFileError('Not logged in!');
+      throw new RejectUpload('Not logged in!');
     }
 
     return {
@@ -101,8 +101,8 @@ route({
 ```
 
 <Callout title="Rejecting uploads">
-  Throw `UploadFileError` to reject the file upload. This will also send the
-  error message to the client.
+  Throw `RejectUpload` to reject the file upload. This will also send the error
+  message to the client.
 </Callout>
 
 You can return an object with the following properties:

--- a/apps/docs/content/docs/routes-single.mdx
+++ b/apps/docs/content/docs/routes-single.mdx
@@ -84,7 +84,9 @@ route({
     }
 
     return {
-      objectKey: user.id,
+      objectInfo: {
+        key: user.id,
+      },
       bucketName: 'another-bucket',
     };
   },
@@ -100,16 +102,16 @@ You can return an object with the following properties:
 
 <TypeTable
   type={{
-    objectKey: {
+    objectInfo: {
       description:
-        'The S3 object key. If not provided, a random key will be generated.',
-      type: 'string',
-      required: false,
-    },
-    objectMetadata: {
-      description:
-        'Metadata to be added to the S3 object. This data will be exposed to the client.',
-      type: 'Record<string, string>',
+        'Information about the S3 object. Includes the object key, metadata, ACL, and other properties.',
+      type: 'object',
+      typeDescription: (
+        <>
+          Includes: <code>key</code>, <code>metadata</code>, <code>acl</code>,{' '}
+          <code>storageClass</code>.
+        </>
+      ),
       required: false,
     },
     metadata: {

--- a/apps/docs/content/docs/routes-single.mdx
+++ b/apps/docs/content/docs/routes-single.mdx
@@ -80,7 +80,7 @@ route({
     const user = await auth();
 
     if (!user) {
-      throw new UploadFileError('Not logged in!');
+      throw new RejectUpload('Not logged in!');
     }
 
     return {
@@ -94,8 +94,8 @@ route({
 ```
 
 <Callout title="Rejecting uploads">
-  Throw `UploadFileError` to reject the file upload. This will also send the
-  error message to the client.
+  Throw `RejectUpload` to reject the file upload. This will also send the error
+  message to the client.
 </Callout>
 
 You can return an object with the following properties:

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/example/next-env.d.ts
+++ b/apps/example/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/example/src/app/api/upload/route.ts
+++ b/apps/example/src/app/api/upload/route.ts
@@ -1,8 +1,8 @@
 import { createUploadRouteHandler, route } from 'better-upload/server';
-import { r2 } from 'better-upload/server/helpers';
+import { cloudflare } from 'better-upload/server/helpers';
 
 export const { POST } = createUploadRouteHandler({
-  client: r2(),
+  client: cloudflare(),
   bucketName: process.env.AWS_BUCKET_NAME!,
   routes: {
     image: route({

--- a/apps/example/src/app/api/upload/route.ts
+++ b/apps/example/src/app/api/upload/route.ts
@@ -18,10 +18,12 @@ export const { POST } = createUploadRouteHandler({
         console.log('Before upload:', uploadId);
 
         return {
-          generateObjectKey({ file }) {
-            console.log('Generate object key:', file.name);
+          generateObjectInfo({ file }) {
+            console.log('Generate object info:', file.name);
 
-            return `multiple/${uploadId}/${file.name}`;
+            return {
+              key: `multiple/${uploadId}/${file.name}`,
+            };
           },
         };
       },
@@ -38,7 +40,7 @@ export const { POST } = createUploadRouteHandler({
       maxFiles: 5,
       onBeforeUpload() {
         return {
-          generateObjectKey: () => `form/${crypto.randomUUID()}`,
+          generateObjectInfo: () => ({ key: `form/${crypto.randomUUID()}` }),
         };
       },
     }),

--- a/packages/better-upload/src/server-helpers/clients/cloudflare.ts
+++ b/packages/better-upload/src/server-helpers/clients/cloudflare.ts
@@ -1,5 +1,5 @@
 import { S3Client } from '@aws-sdk/client-s3';
-import type { CreateR2ClientParams } from '../types/internal';
+import type { CreateCloudflareClientParams } from '../types/internal';
 
 /**
  * Create a Cloudflare R2 client, compatible with the S3 API.
@@ -10,7 +10,7 @@ import type { CreateR2ClientParams } from '../types/internal';
  * - `AWS_SECRET_ACCESS_KEY`
  * - `CLOUDFLARE_JURISDICTION`
  */
-export function r2(params?: CreateR2ClientParams) {
+export function cloudflare(params?: CreateCloudflareClientParams) {
   const { accountId, accessKeyId, secretAccessKey, jurisdiction } = params ?? {
     accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
     accessKeyId:
@@ -27,7 +27,7 @@ export function r2(params?: CreateR2ClientParams) {
   };
 
   if (!accountId || !accessKeyId || !secretAccessKey) {
-    throw new Error('Missing required parameters for R2 client.');
+    throw new Error('Missing required parameters for Cloudflare R2 client.');
   }
 
   return new S3Client({

--- a/packages/better-upload/src/server-helpers/clients/digital-ocean.ts
+++ b/packages/better-upload/src/server-helpers/clients/digital-ocean.ts
@@ -17,7 +17,9 @@ export function digitalOcean(params?: CreateDigitalOceanClientParams) {
   };
 
   if (!region || !key || !secret) {
-    throw new Error('Missing required parameters for DigitalOcean client.');
+    throw new Error(
+      'Missing required parameters for DigitalOcean Spaces client.'
+    );
   }
 
   return new S3Client({

--- a/packages/better-upload/src/server-helpers/clients/index.ts
+++ b/packages/better-upload/src/server-helpers/clients/index.ts
@@ -1,6 +1,6 @@
 export * from './backblaze';
+export * from './cloudflare';
 export * from './digital-ocean';
 export * from './minio';
-export * from './r2';
 export * from './tigris';
 export * from './wasabi';

--- a/packages/better-upload/src/server-helpers/types/internal.ts
+++ b/packages/better-upload/src/server-helpers/types/internal.ts
@@ -12,7 +12,7 @@ export type HelperBaseParams = {
   bucketName: string;
 };
 
-export type CreateR2ClientParams = {
+export type CreateCloudflareClientParams = {
   /**
    * Cloudflare account ID.
    */

--- a/packages/better-upload/src/server/error.ts
+++ b/packages/better-upload/src/server/error.ts
@@ -1,6 +1,6 @@
-export class UploadFileError extends Error {
+export class RejectUpload extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'UploadFileError';
+    this.name = 'RejectUpload';
   }
 }

--- a/packages/better-upload/src/server/router/handlers/files-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/files-handler.ts
@@ -105,6 +105,7 @@ export async function handleFiles({
       let objectKey = `${crypto.randomUUID()}-${createSlug(file.name)}`;
       let objectMetadata = {} as ObjectMetadata;
       let objectAcl = undefined;
+      let objectStorageClass = undefined;
 
       if (generateObjectInfoCallback) {
         const objectInfo = await generateObjectInfoCallback({ file });
@@ -122,6 +123,7 @@ export async function handleFiles({
         }
 
         objectAcl = objectInfo.acl;
+        objectStorageClass = objectInfo.storageClass;
       }
 
       const signedUrl = await getSignedUrl(
@@ -133,6 +135,7 @@ export async function handleFiles({
           ContentLength: file.size,
           Metadata: objectMetadata,
           ACL: objectAcl,
+          StorageClass: objectStorageClass,
         }),
         {
           expiresIn: signedUrlExpiresIn,

--- a/packages/better-upload/src/server/router/handlers/files-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/files-handler.ts
@@ -104,6 +104,7 @@ export async function handleFiles({
     files.map(async (file) => {
       let objectKey = `${crypto.randomUUID()}-${createSlug(file.name)}`;
       let objectMetadata = {} as ObjectMetadata;
+      let objectAcl = undefined;
 
       if (generateObjectInfoCallback) {
         const objectInfo = await generateObjectInfoCallback({ file });
@@ -119,6 +120,8 @@ export async function handleFiles({
             ])
           );
         }
+
+        objectAcl = objectInfo.acl;
       }
 
       const signedUrl = await getSignedUrl(
@@ -129,6 +132,7 @@ export async function handleFiles({
           ContentType: file.type,
           ContentLength: file.size,
           Metadata: objectMetadata,
+          ACL: objectAcl,
         }),
         {
           expiresIn: signedUrlExpiresIn,

--- a/packages/better-upload/src/server/router/handlers/files-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/files-handler.ts
@@ -1,5 +1,5 @@
 import { config } from '@/server/config';
-import { UploadFileError } from '@/server/error';
+import { RejectUpload } from '@/server/error';
 import type { ObjectMetadata, Route } from '@/server/types/internal';
 import { isFileTypeAllowed } from '@/server/utils/internal/file-type';
 import { createSlug } from '@/server/utils/internal/slug';
@@ -90,7 +90,7 @@ export async function handleFiles({
     bucketName = onBeforeUpload?.bucketName || defaultBucketName;
     generateObjectInfoCallback = onBeforeUpload?.generateObjectInfo || null;
   } catch (error) {
-    if (error instanceof UploadFileError) {
+    if (error instanceof RejectUpload) {
       return Response.json(
         { error: { type: 'rejected', message: error.message } },
         { status: 400 }

--- a/packages/better-upload/src/server/router/handlers/multipart-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/multipart-handler.ts
@@ -103,6 +103,7 @@ export async function handleMultipartFiles({
       let objectKey = `${crypto.randomUUID()}-${createSlug(file.name)}`;
       let objectMetadata = {} as ObjectMetadata;
       let objectAcl = undefined;
+      let objectStorageClass = undefined;
 
       if (generateObjectInfoCallback) {
         const objectInfo = await generateObjectInfoCallback({ file });
@@ -120,6 +121,7 @@ export async function handleMultipartFiles({
         }
 
         objectAcl = objectInfo.acl;
+        objectStorageClass = objectInfo.storageClass;
       }
 
       const { UploadId: s3UploadId } = await client.send(
@@ -129,6 +131,7 @@ export async function handleMultipartFiles({
           ContentType: file.type,
           Metadata: objectMetadata,
           ACL: objectAcl,
+          StorageClass: objectStorageClass,
         })
       );
 

--- a/packages/better-upload/src/server/router/handlers/multipart-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/multipart-handler.ts
@@ -102,6 +102,7 @@ export async function handleMultipartFiles({
     files.map(async (file) => {
       let objectKey = `${crypto.randomUUID()}-${createSlug(file.name)}`;
       let objectMetadata = {} as ObjectMetadata;
+      let objectAcl = undefined;
 
       if (generateObjectInfoCallback) {
         const objectInfo = await generateObjectInfoCallback({ file });
@@ -117,6 +118,8 @@ export async function handleMultipartFiles({
             ])
           );
         }
+
+        objectAcl = objectInfo.acl;
       }
 
       const { UploadId: s3UploadId } = await client.send(
@@ -125,6 +128,7 @@ export async function handleMultipartFiles({
           Key: objectKey,
           ContentType: file.type,
           Metadata: objectMetadata,
+          ACL: objectAcl,
         })
       );
 

--- a/packages/better-upload/src/server/router/handlers/multipart-handler.ts
+++ b/packages/better-upload/src/server/router/handlers/multipart-handler.ts
@@ -1,5 +1,5 @@
 import { config } from '@/server/config';
-import { UploadFileError } from '@/server/error';
+import { RejectUpload } from '@/server/error';
 import type { ObjectMetadata, Route } from '@/server/types/internal';
 import { isFileTypeAllowed } from '@/server/utils/internal/file-type';
 import { createSlug } from '@/server/utils/internal/slug';
@@ -88,7 +88,7 @@ export async function handleMultipartFiles({
     bucketName = onBeforeUpload?.bucketName || defaultBucketName;
     generateObjectInfoCallback = onBeforeUpload?.generateObjectInfo || null;
   } catch (error) {
-    if (error instanceof UploadFileError) {
+    if (error instanceof RejectUpload) {
       return Response.json(
         { error: { type: 'rejected', message: error.message } },
         { status: 400 }

--- a/packages/better-upload/src/server/types/internal.ts
+++ b/packages/better-upload/src/server/types/internal.ts
@@ -1,3 +1,4 @@
+import type { ObjectCannedACL } from '@aws-sdk/client-s3';
 import type { StandardSchemaV1 } from './standard-schema';
 
 export type UnknownMetadata = Record<string, unknown>;
@@ -251,6 +252,11 @@ export type BeforeUploadCallbackObjectInfo = {
    * **WARNING:** All values here will be exposed to the client. Do not use this for sensitive data.
    */
   metadata?: ObjectMetadata;
+
+  /**
+   * ACL (access control list) to apply to the S3 object.
+   */
+  acl?: ObjectCannedACL;
 };
 
 type BeforeUploadCallbackResult<
@@ -276,6 +282,7 @@ type BeforeUploadCallbackResult<
        * Options:
        * - `key`: The S3 object key to upload to.
        * - `metadata`: Custom S3 object metadata.
+       * - `acl`: ACL to apply to the S3 object.
        */
       objectInfo?: BeforeUploadCallbackObjectInfo;
     }
@@ -286,6 +293,7 @@ type BeforeUploadCallbackResult<
        * Options:
        * - `key`: The S3 object key to upload to.
        * - `metadata`: Custom S3 object metadata.
+       * - `acl`: ACL to apply to the S3 object.
        */
       generateObjectInfo?: (data: {
         /**

--- a/packages/better-upload/src/server/types/internal.ts
+++ b/packages/better-upload/src/server/types/internal.ts
@@ -96,7 +96,7 @@ export type RouteConfig<
   clientMetadataSchema?: ClientMetadataSchema;
 
   /**
-   * Use this callback to run custom logic before uploading a file, such as auth and rate-limiting. You can also return a custom object key (return `generateObjectKey` for multiple files). This runs only once regardless of the number of files uploaded.
+   * Use this callback to run custom logic before uploading a file, such as auth and rate-limiting. You can also return `objectInfo` to customize the S3 object (`generateObjectInfo` for multiple files). This runs only once regardless of the number of files uploaded.
    *
    * Metadata sent from the client is also available.
    *

--- a/packages/better-upload/src/server/types/internal.ts
+++ b/packages/better-upload/src/server/types/internal.ts
@@ -1,4 +1,4 @@
-import type { ObjectCannedACL } from '@aws-sdk/client-s3';
+import type { ObjectCannedACL, StorageClass } from '@aws-sdk/client-s3';
 import type { StandardSchemaV1 } from './standard-schema';
 
 export type UnknownMetadata = Record<string, unknown>;
@@ -257,6 +257,11 @@ export type BeforeUploadCallbackObjectInfo = {
    * ACL (access control list) to apply to the S3 object.
    */
   acl?: ObjectCannedACL;
+
+  /**
+   * Storage class to apply to the S3 object.
+   */
+  storageClass?: StorageClass;
 };
 
 type BeforeUploadCallbackResult<
@@ -283,6 +288,7 @@ type BeforeUploadCallbackResult<
        * - `key`: The S3 object key to upload to.
        * - `metadata`: Custom S3 object metadata.
        * - `acl`: ACL to apply to the S3 object.
+       * - `storageClass`: Storage class to apply to the S3 object.
        */
       objectInfo?: BeforeUploadCallbackObjectInfo;
     }
@@ -294,6 +300,7 @@ type BeforeUploadCallbackResult<
        * - `key`: The S3 object key to upload to.
        * - `metadata`: Custom S3 object metadata.
        * - `acl`: ACL to apply to the S3 object.
+       * - `storageClass`: Storage class to apply to the S3 object.
        */
       generateObjectInfo?: (data: {
         /**

--- a/packages/better-upload/src/server/types/internal.ts
+++ b/packages/better-upload/src/server/types/internal.ts
@@ -100,7 +100,7 @@ export type RouteConfig<
    *
    * Metadata sent from the client is also available.
    *
-   * Throw an `UploadFileError` to reject the file upload. This will also send the error message to the client.
+   * Throw `RejectUpload` to reject the file upload. This will also send the error message to the client.
    */
   onBeforeUpload?: (
     data: {

--- a/packages/better-upload/src/server/utils/router.ts
+++ b/packages/better-upload/src/server/utils/router.ts
@@ -52,6 +52,7 @@ export function route<
                           key: res.objectInfo!.key,
                           metadata: res.objectInfo!.metadata,
                           acl: res.objectInfo!.acl,
+                          storageClass: res.objectInfo!.storageClass,
                         }) as BeforeUploadCallbackObjectInfo
                     : undefined;
 

--- a/packages/better-upload/src/server/utils/router.ts
+++ b/packages/better-upload/src/server/utils/router.ts
@@ -1,6 +1,6 @@
 import type {
+  BeforeUploadCallbackObjectInfo,
   ExecRoute,
-  ObjectMetadata,
   Route,
   RouteConfig,
   UnknownMetadata,
@@ -43,25 +43,21 @@ export function route<
             } as any);
 
             if (res) {
-              const generateObjectKey =
-                'generateObjectKey' in res
-                  ? res.generateObjectKey
-                  : 'objectKey' in res
-                    ? () => res.objectKey as string
-                    : undefined;
-
-              const generateObjectMetadata =
-                'generateObjectMetadata' in res
-                  ? res.generateObjectMetadata
-                  : 'objectMetadata' in res
-                    ? () => res.objectMetadata as ObjectMetadata
+              const generateObjectInfo =
+                'generateObjectInfo' in res
+                  ? res.generateObjectInfo
+                  : 'objectInfo' in res
+                    ? () =>
+                        ({
+                          key: res.objectInfo!.key,
+                          metadata: res.objectInfo!.metadata,
+                        }) as BeforeUploadCallbackObjectInfo
                     : undefined;
 
               return {
                 metadata: res.metadata,
                 bucketName: res.bucketName,
-                generateObjectKey,
-                generateObjectMetadata,
+                generateObjectInfo,
               };
             } else {
               return res;

--- a/packages/better-upload/src/server/utils/router.ts
+++ b/packages/better-upload/src/server/utils/router.ts
@@ -51,6 +51,7 @@ export function route<
                         ({
                           key: res.objectInfo!.key,
                           metadata: res.objectInfo!.metadata,
+                          acl: res.objectInfo!.acl,
                         }) as BeforeUploadCallbackObjectInfo
                     : undefined;
 


### PR DESCRIPTION
This PR introduces:

- `objectInfo` object returned in `onBeforeUpload` instead of separate properties.
- `r2` helper renamed to `cloudflare`.
- `UploadFileError` renamed to `RejectUpload`.

Closes #54
Closes #52 