### PR TITLE
fix: add putObject->`contentLength` param for Streams

### DIFF
--- a/.changeset/many-rockets-brush.md
+++ b/.changeset/many-rockets-brush.md
@@ -1,0 +1,5 @@
+---
+'@better-upload/server': patch
+---
+
+Add `contentLength` param to `putObject` helper

--- a/packages/server/src/helpers/s3/put-object.ts
+++ b/packages/server/src/helpers/s3/put-object.ts
@@ -27,10 +27,7 @@ export async function putObject(
     tagging?: Tagging;
   }
 ) {
-  let contentLength = getBodyContentLength(params.body);
-  if (params.contentLength) {
-    contentLength = params.contentLength;
-  }
+  const contentLength = params.contentLength ?? getBodyContentLength(params.body);
 
   await throwS3Error(
     client.s3.fetch(`${client.buildBucketUrl(params.bucket)}/${params.key}`, {

--- a/packages/server/src/helpers/s3/put-object.ts
+++ b/packages/server/src/helpers/s3/put-object.ts
@@ -19,6 +19,7 @@ export async function putObject(
     key: string;
     body: BodyInit;
     contentType: string;
+    contentLength?: number;
     metadata?: ObjectMetadata;
     acl?: ObjectAcl;
     storageClass?: StorageClass;
@@ -26,7 +27,10 @@ export async function putObject(
     tagging?: Tagging;
   }
 ) {
-  const contentLength = getBodyContentLength(params.body);
+  let contentLength = getBodyContentLength(params.body);
+  if (params.contentLength) {
+    contentLength = params.contentLength;
+  }
 
   await throwS3Error(
     client.s3.fetch(`${client.buildBucketUrl(params.bucket)}/${params.key}`, {


### PR DESCRIPTION
`putObject` requires a content-length header when uploading to Cloudflare. A supplied ReadableStream object cannot always supply the needed length for this to function.

Adding an optional `contentLength` to the `putObject` method allows manually supply this missing data required to function.