### PR TITLE
feat(skills): add better-upload agent skill

### DIFF
--- a/apps/docs/content/docs/quickstart.mdx
+++ b/apps/docs/content/docs/quickstart.mdx
@@ -153,6 +153,19 @@ Learn more about CORS [here](https://docs.aws.amazon.com/AmazonS3/latest/usergui
 
 </Step>
 
+<Step>
+
+### Install AI Agent Skills (Optional)
+
+Using an AI coding assistant like Claude Code, OpenCode, Cursor, Antigravity, etc? Install the Better Upload Agent Skills to help your agent work more effectively with this library:
+
+```npm
+npx skills add Nic13Gamer/better-upload
+```
+
+</Step>
+
+
 </Steps>
 
 ## Learn more

--- a/skills/better-upload/SKILL.md
+++ b/skills/better-upload/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: better-upload
+description: Use when working with better-upload, adding file uploads to a React or Next.js app using pre-signed S3 URLs, configuring upload routes or callbacks (onBeforeUpload, onAfterSignedUrl, RejectUpload), setting up S3 clients (AWS S3, Cloudflare R2, MinIO, Backblaze, DigitalOcean Spaces, Tigris, Wasabi), using useUploadFiles or useUploadFile hooks, implementing multipart uploads, managing upload progress or abort, using uploadFile/uploadFiles imperatively, integrating with TanStack Query or React Hook Form, working with S3 helpers (deleteObject, presignGetObject, moveObject), or using UploadDropzone/UploadButton components.
+---
+
+# Better Upload
+
+Better Upload enables direct file uploads from the browser to any S3-compatible storage using pre-signed URLs. The server generates temporary signed URLs; the client uploads directly to S3 without proxying through your server.
+
+## Architecture
+
+```
+Browser → (1) POST /api/upload → Your Server (@better-upload/server)
+                                       ↓ generates pre-signed URL
+Browser → (2) PUT signed URL → S3 Bucket (AWS, R2, MinIO, etc.)
+```
+
+## Packages
+
+| Package | Role |
+|---|---|
+| `@better-upload/server` | Router, routes, S3 clients, object helpers |
+| `@better-upload/client` | React hooks (`useUploadFiles`, `useUploadFile`), imperative upload functions |
+
+## Installation
+
+```bash
+npm i @better-upload/server @better-upload/client
+```
+
+## Quick Start
+
+### Server — Next.js App Router
+
+```ts title="app/api/upload/route.ts"
+import { route, type Router } from '@better-upload/server';
+import { toRouteHandler } from '@better-upload/server/adapters/next';
+import { cloudflare } from '@better-upload/server/clients';
+
+const router: Router = {
+  client: cloudflare(), // reads env vars automatically
+  bucketName: process.env.AWS_BUCKET_NAME!,
+  routes: {
+    images: route({
+      multipleFiles: true,
+      fileTypes: ['image/*'],
+      maxFileSize: 1024 * 1024 * 5, // 5MB
+      maxFiles: 4,
+    }),
+  },
+};
+
+export const { POST } = toRouteHandler(router);
+```
+
+### Client — React hook
+
+```tsx title="components/uploader.tsx"
+'use client'; // only in Next.js
+
+import { useUploadFiles } from '@better-upload/client';
+
+export function Uploader() {
+  const { upload, isPending, uploadedFiles } = useUploadFiles({
+    route: 'images', // must match the route name in the server router
+  });
+
+  return (
+    <input
+      type="file"
+      multiple
+      disabled={isPending}
+      onChange={(e) => {
+        if (e.target.files) upload(e.target.files);
+      }}
+    />
+  );
+}
+```
+
+The default API endpoint is `/api/upload`. Override with `api: '/your/path'` if needed.
+
+---
+
+## Reference Files
+
+Read only the file(s) relevant to the current task.
+
+### [`reference/server.md`](reference/server.md)
+Router type, `route()` options (single and multiple files), `onBeforeUpload` / `onAfterSignedUrl` callbacks, `RejectUpload`, multipart uploads, adapters (Next.js, Node.js), all S3 clients with their env vars.
+
+### [`reference/client.md`](reference/client.md)
+`useUploadFiles` and `useUploadFile` hooks — all options, return values, and events (`onBeforeUpload`, `onUploadBegin`, `onUploadProgress`, `onUploadComplete`, `onUploadFail`, `onError`, `onUploadSettle`). Imperative functions (`uploadFile`, `uploadFiles`). Pre-built shadcn components.
+
+### [`reference/helpers.md`](reference/helpers.md)
+Server-side S3 helpers from `@better-upload/server/helpers`: `presignGetObject`, `getObject`, `headObject`, `listObjectsV2`, `putObject`, `deleteObject`, `deleteObjects`, `moveObject`, `copyObject`, object tagging, and low-level multipart helpers. Client-side: `formatBytes`.
+
+---
+
+## Examples
+
+Focused, copy-paste examples for common patterns.
+
+| Example | File |
+|---|---|
+| Full multi-route server setup | [`examples/server-router.md`](examples/server-router.md) |
+| Auth + access control with `RejectUpload` | [`examples/authentication.md`](examples/authentication.md) |
+| Single file upload (avatar) | [`examples/single-file-upload.md`](examples/single-file-upload.md) |
+| Client metadata + Zod validation | [`examples/client-metadata.md`](examples/client-metadata.md) |
+| TanStack Query integration | [`examples/tanstack-query.md`](examples/tanstack-query.md) |
+| Pre-built Dropzone component | [`examples/dropzone-component.md`](examples/dropzone-component.md) |
+| Cancel / abort an upload | [`examples/abort-upload.md`](examples/abort-upload.md) |
+| Delete files from S3 | [`examples/delete-files.md`](examples/delete-files.md) |
+| CORS configuration | [`examples/cors-configuration.md`](examples/cors-configuration.md) |

--- a/skills/better-upload/examples/abort-upload.md
+++ b/skills/better-upload/examples/abort-upload.md
@@ -1,0 +1,43 @@
+# Example: Abort / Cancel Upload
+
+Use an `AbortController` to cancel an in-progress upload. Pass the signal via the hook options or directly to the `upload()` call.
+
+```tsx
+'use client';
+
+import { useRef } from 'react';
+import { useUploadFiles } from '@better-upload/client';
+
+export function CancellableUploader() {
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const { upload, isPending, isAborted } = useUploadFiles({ route: 'images' });
+
+  function startUpload(files: FileList) {
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    upload(files, { signal: controller.signal });
+  }
+
+  function cancelUpload() {
+    controllerRef.current?.abort();
+  }
+
+  return (
+    <>
+      <input
+        type="file"
+        multiple
+        disabled={isPending}
+        onChange={(e) => e.target.files && startUpload(e.target.files)}
+      />
+      {isPending && (
+        <button onClick={cancelUpload}>Cancel upload</button>
+      )}
+      {isAborted && <p>Upload was cancelled.</p>}
+    </>
+  );
+}
+```
+
+> See [`reference/client.md`](../reference/client.md) for the `signal`, `isAborted`, and other hook state.

--- a/skills/better-upload/examples/authentication.md
+++ b/skills/better-upload/examples/authentication.md
@@ -1,0 +1,39 @@
+# Example: Authentication and Access Control
+
+Use `onBeforeUpload` to protect routes. Throw `RejectUpload` to deny the upload and send the message back to the client.
+
+```ts
+import { route, RejectUpload } from '@better-upload/server';
+import { auth } from '@/lib/auth';
+
+const imagesRoute = route({
+  multipleFiles: true,
+  fileTypes: ['image/*'],
+  maxFileSize: 1024 * 1024 * 5, // 5MB
+
+  onBeforeUpload: async ({ req, files, clientMetadata }) => {
+    const user = await auth();
+    if (!user) throw new RejectUpload('Not logged in!');
+
+    return {
+      generateObjectInfo: ({ file }) => ({
+        key: `users/${user.id}/${crypto.randomUUID()}/${file.name}`,
+      }),
+      metadata: { userId: user.id }, // passed through to onAfterSignedUrl
+    };
+  },
+
+  onAfterSignedUrl: async ({ req, files, metadata }) => {
+    // Save file records to DB after signed URLs are generated
+    await db.files.createMany({
+      data: files.map((f) => ({
+        key: f.objectInfo.key,
+        userId: metadata.userId,
+      })),
+    });
+    return { metadata: { saved: true } };
+  },
+});
+```
+
+> See [`reference/server.md`](../reference/server.md) for the full callbacks API.

--- a/skills/better-upload/examples/client-metadata.md
+++ b/skills/better-upload/examples/client-metadata.md
@@ -1,0 +1,53 @@
+# Example: Client Metadata with Zod Validation
+
+Send contextual data from the client (e.g., a folder name) and validate it on the server using any Standard Schema-compatible library like Zod.
+
+**Server** — define the schema in the route:
+
+```ts
+import { z } from 'zod';
+import { route } from '@better-upload/server';
+
+const uploadRoute = route({
+  multipleFiles: true,
+  clientMetadataSchema: z.object({
+    folder: z.string(),
+    isPublic: z.boolean().optional(),
+  }),
+  onBeforeUpload: async ({ clientMetadata }) => {
+    // clientMetadata is typed and validated at this point
+    return {
+      generateObjectInfo: ({ file }) => ({
+        key: `${clientMetadata.folder}/${file.name}`,
+      }),
+    };
+  },
+});
+```
+
+**Client** — pass metadata when calling `upload`:
+
+```tsx
+import { useUploadFiles } from '@better-upload/client';
+
+export function Uploader() {
+  const { upload } = useUploadFiles({ route: 'images' });
+
+  return (
+    <input
+      type="file"
+      multiple
+      onChange={(e) => {
+        if (e.target.files) {
+          upload(e.target.files, {
+            metadata: { folder: 'profile-pics', isPublic: false },
+          });
+        }
+      }}
+    />
+  );
+}
+```
+
+> See [`reference/client.md`](../reference/client.md) for the full `useUploadFiles` options.  
+> See [`reference/server.md`](../reference/server.md) for the `clientMetadataSchema` option.

--- a/skills/better-upload/examples/cors-configuration.md
+++ b/skills/better-upload/examples/cors-configuration.md
@@ -1,0 +1,35 @@
+# Example: CORS Configuration
+
+Your S3 bucket must be configured to accept cross-origin upload requests from the browser. Without this, direct uploads will fail.
+
+## Required CORS policy
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "https://your-domain.com"
+    ],
+    "AllowedMethods": ["GET", "PUT", "POST", "DELETE"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"]
+  }
+]
+```
+
+> `ETag` must be exposed — it is required for multipart uploads to complete successfully.
+
+## Where to configure
+
+- **AWS S3**: S3 Console → Bucket → Permissions → Cross-origin resource sharing (CORS)
+- **Cloudflare R2**: R2 Dashboard → Bucket → Settings → CORS Policy
+- **MinIO**: `mc cors set` command or the MinIO Console
+
+## Notes
+
+- Add all domains where your app is served to `AllowedOrigins`
+- `AllowedMethods` must include `PUT` (used for pre-signed URL uploads) and `DELETE` (for multipart abort)
+- `AllowedHeaders: ["*"]` is the safest default; tighten if needed
+
+> See the [official AWS CORS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html) for more detail.

--- a/skills/better-upload/examples/delete-files.md
+++ b/skills/better-upload/examples/delete-files.md
@@ -1,0 +1,36 @@
+# Example: Delete Files After Upload
+
+Use the `deleteObject` helper in a server route to delete uploaded files.
+
+```ts title="app/api/files/[key]/route.ts"
+import { deleteObject } from '@better-upload/server/helpers';
+import { s3 } from '@/lib/s3'; // your configured S3 client
+import { requireAuth } from '@/lib/auth';
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { key: string } }
+) {
+  const user = await requireAuth(request);
+
+  await deleteObject(s3, {
+    bucket: process.env.AWS_BUCKET_NAME!,
+    key: `users/${user.id}/${params.key}`,
+  });
+
+  return Response.json({ success: true });
+}
+```
+
+## Batch delete
+
+```ts
+import { deleteObjects } from '@better-upload/server/helpers';
+
+const { deleted, errors } = await deleteObjects(s3, {
+  bucket: process.env.AWS_BUCKET_NAME!,
+  objects: [{ key: 'file1.png' }, { key: 'file2.png' }],
+});
+```
+
+> See [`reference/helpers.md`](../reference/helpers.md) for all available S3 object helpers.

--- a/skills/better-upload/examples/dropzone-component.md
+++ b/skills/better-upload/examples/dropzone-component.md
@@ -1,0 +1,53 @@
+# Example: Pre-built Dropzone Component
+
+Better Upload ships optional shadcn-compatible UI components. The `UploadDropzone` component wraps the `useUploadFiles` hook automatically via the `control` prop.
+
+## Install the component
+
+```bash
+npx shadcn@latest add @better-upload/upload-dropzone
+```
+
+## Usage
+
+```tsx title="components/image-uploader.tsx"
+'use client';
+
+import { useUploadFiles } from '@better-upload/client';
+import { UploadDropzone } from '@/components/ui/upload-dropzone';
+
+export function ImageUploader() {
+  const { control, uploadedFiles, isPending } = useUploadFiles({
+    route: 'images',
+    onUploadComplete: ({ files }) => {
+      console.log('Uploaded:', files);
+    },
+    onError: (error) => {
+      console.error(error.message);
+    },
+  });
+
+  return (
+    <UploadDropzone
+      control={control}
+      accept="image/*"
+      description={{
+        maxFiles: 4,
+        maxFileSize: '5MB',
+        fileTypes: 'JPEG, PNG, GIF',
+      }}
+    />
+  );
+}
+```
+
+## Other available components
+
+| Component | Install command | Use |
+|---|---|---|
+| `<UploadButton />` | `npx shadcn@latest add @better-upload/upload-button` | Single file button |
+| `<UploadDropzone />` | `npx shadcn@latest add @better-upload/upload-dropzone` | Multiple files dropzone |
+| `<UploadProgress />` | `npx shadcn@latest add @better-upload/upload-progress` | Progress display |
+| `<PasteUploadArea />` | `npx shadcn@latest add @better-upload/paste-upload-area` | Paste-to-upload wrapper |
+
+> See [`reference/client.md`](../reference/client.md) for the `control` prop and hook state.

--- a/skills/better-upload/examples/server-router.md
+++ b/skills/better-upload/examples/server-router.md
@@ -1,0 +1,49 @@
+# Example: Full Server Router
+
+A complete Next.js upload handler with multiple routes (single file, multiple files, and multipart).
+
+```ts title="app/api/upload/route.ts"
+import { route, type Router } from '@better-upload/server';
+import { toRouteHandler } from '@better-upload/server/adapters/next';
+import { cloudflare } from '@better-upload/server/clients';
+
+const router: Router = {
+  client: cloudflare(), // reads CLOUDFLARE_ACCOUNT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+  bucketName: process.env.AWS_BUCKET_NAME!,
+  routes: {
+    // Single file image upload
+    image: route({
+      fileTypes: ['image/*'],
+      maxFileSize: 1024 * 1024 * 2, // 2MB
+    }),
+
+    // Multiple image upload with unique keys per file
+    images: route({
+      fileTypes: ['image/*'],
+      multipleFiles: true,
+      maxFiles: 4,
+      onBeforeUpload() {
+        const uploadId = crypto.randomUUID();
+        return {
+          generateObjectInfo({ file }) {
+            return { key: `uploads/${uploadId}/${file.name}` };
+          },
+        };
+      },
+    }),
+
+    // Multipart upload for large files
+    multipart: route({
+      multipart: true,
+      multipleFiles: true,
+      maxFiles: 5,
+      partSize: 1024 * 1024 * 5,    // 5MB per part
+      maxFileSize: 1024 * 1024 * 80, // 80MB max per file
+    }),
+  },
+};
+
+export const { POST } = toRouteHandler(router);
+```
+
+> See [`reference/server.md`](../reference/server.md) for all router and route options.

--- a/skills/better-upload/examples/single-file-upload.md
+++ b/skills/better-upload/examples/single-file-upload.md
@@ -1,0 +1,58 @@
+# Example: Single File Upload (Profile Avatar)
+
+Upload a single file with a fixed key — useful for profile pictures that overwrite each other.
+
+**Server:**
+
+```ts
+import { route, RejectUpload } from '@better-upload/server';
+import { requireAuth } from '@/lib/auth';
+
+const avatarRoute = route({
+  fileTypes: ['image/jpeg', 'image/png', 'image/webp'],
+  maxFileSize: 1024 * 1024, // 1MB
+
+  onBeforeUpload: async ({ req, file }) => {
+    const user = await requireAuth(req);
+    return {
+      objectInfo: {
+        key: `avatars/${user.id}`, // same key every time — overwrites the existing avatar
+      },
+    };
+  },
+});
+```
+
+**Client:**
+
+```tsx
+'use client';
+
+import { useUploadFile } from '@better-upload/client';
+import { toast } from 'sonner';
+
+export function AvatarUploader() {
+  const { upload, isPending, isSuccess, uploadedFile } = useUploadFile({
+    route: 'avatar',
+    onUploadComplete: ({ file, metadata }) => {
+      toast.success('Avatar updated!');
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  return (
+    <input
+      type="file"
+      accept="image/*"
+      disabled={isPending}
+      onChange={(e) => {
+        if (e.target.files?.[0]) upload(e.target.files[0]);
+      }}
+    />
+  );
+}
+```
+
+> See [`reference/client.md`](../reference/client.md) for the full `useUploadFile` API.

--- a/skills/better-upload/examples/tanstack-query.md
+++ b/skills/better-upload/examples/tanstack-query.md
@@ -1,0 +1,72 @@
+# Example: TanStack Query Integration
+
+If you prefer managing async state yourself, use the imperative `uploadFiles` / `uploadFile` functions with `useMutation`.
+
+## Multiple files
+
+```tsx title="components/uploader.tsx"
+'use client';
+
+import { uploadFiles } from '@better-upload/client';
+import { useMutation } from '@tanstack/react-query';
+
+export function Uploader() {
+  const { mutate: upload, isPending } = useMutation({
+    mutationFn: (files: File[]) =>
+      uploadFiles({
+        files,
+        route: 'images',
+        onFileStateChange: ({ file }) => {
+          console.log(`${file.name}: ${Math.round(file.progress * 100)}%`);
+        },
+      }),
+    onSuccess: ({ files, failedFiles, metadata }) => {
+      console.log(`${files.length} files uploaded`);
+    },
+    onError: (error) => console.error(error),
+  });
+
+  return (
+    <input
+      type="file"
+      multiple
+      disabled={isPending}
+      onChange={(e) => {
+        if (e.target.files) upload(Array.from(e.target.files));
+      }}
+    />
+  );
+}
+```
+
+## Single file
+
+```tsx
+import { uploadFile } from '@better-upload/client';
+import { useMutation } from '@tanstack/react-query';
+
+export function AvatarUploader() {
+  const { mutate: upload, isPending } = useMutation({
+    mutationFn: (file: File) =>
+      uploadFile({
+        file,
+        route: 'avatar',
+        onFileStateChange: ({ file }) => console.log(file.progress),
+      }),
+    onSuccess: ({ file, metadata }) => console.log('Uploaded:', file),
+    onError: (error) => console.error(error),
+  });
+
+  return (
+    <input
+      type="file"
+      disabled={isPending}
+      onChange={(e) => {
+        if (e.target.files?.[0]) upload(e.target.files[0]);
+      }}
+    />
+  );
+}
+```
+
+> See [`reference/client.md`](../reference/client.md) for `uploadFiles` and `uploadFile` full API.

--- a/skills/better-upload/reference/client.md
+++ b/skills/better-upload/reference/client.md
@@ -1,0 +1,224 @@
+# Client Reference — `@better-upload/client`
+
+## `useUploadFiles` — Multiple Files
+
+```tsx
+import { useUploadFiles } from '@better-upload/client';
+
+const {
+  upload,          // (files: FileList | File[], options?) => void
+  uploadAsync,     // same but returns a Promise
+  reset,           // () => void — clear state
+  control,         // pass to pre-built components like <UploadDropzone>
+
+  // state
+  uploadedFiles,   // File[] — files that succeeded
+  failedFiles,     // File[] — files that failed
+  progresses,      // Map<string, number> — progress per file (0–1)
+  averageProgress, // number — average progress of all files (0–1)
+  isPending,       // boolean
+  isAborted,       // boolean
+  isSettled,       // boolean — upload finished (success or error)
+  isError,         // boolean
+  allSucceeded,    // boolean — true if every file uploaded successfully
+  hasFailedFiles,  // boolean
+  error,           // Error | null
+  metadata,        // object | null — server metadata returned by onAfterSignedUrl
+} = useUploadFiles({
+  route: 'images',  // REQUIRED — must match a route name in your server router
+  api: '/api/upload',        // optional, default: '/api/upload'
+  uploadBatchSize: 3,        // optional, upload N files in parallel (default: all)
+  multipartBatchSize: 5,     // optional, upload N parts in parallel (default: all)
+  signal: abortController.signal, // optional
+  headers: { Authorization: `Bearer ${token}` }, // optional
+  credentials: 'include',    // optional: 'include' | 'same-origin' | 'omit'
+  retry: 2,                  // optional, retry count on network failure (default: 0)
+  retryDelay: 1000,          // optional, ms between retries (default: 0)
+});
+```
+
+### Events for `useUploadFiles`
+
+```tsx
+useUploadFiles({
+  route: 'images',
+
+  // Called before requesting signed URLs. Return modified files to transform them.
+  onBeforeUpload: ({ files }) => {
+    return files.map((file) => new File([file], 'renamed-' + file.name, { type: file.type }));
+  },
+
+  // Called after server responds with signed URLs, before upload to S3 starts.
+  onUploadBegin: ({ files, metadata }) => {
+    console.log('Starting upload of', files.length, 'files');
+  },
+
+  // Called whenever any file's progress changes.
+  onUploadProgress: ({ file }) => {
+    console.log(`${file.name}: ${file.progress * 100}%`);
+  },
+
+  // Called after at least one file succeeds (even if others failed).
+  onUploadComplete: ({ files, failedFiles, metadata }) => {
+    console.log(`${files.length} files uploaded`);
+  },
+
+  // Called if at least one file fails (even if others succeeded).
+  onUploadFail: ({ succeededFiles, failedFiles, metadata }) => {
+    console.log('Some files failed:', failedFiles);
+  },
+
+  // Called when a critical error occurs before upload to S3 (e.g., server unreachable, invalid input).
+  onError: (error) => {
+    console.error('Upload error:', error.message);
+  },
+
+  // Called when the upload settles (success or error).
+  onUploadSettle: ({ files, failedFiles, metadata }) => {
+    console.log('Upload finished');
+  },
+});
+```
+
+### Sending metadata from client (`useUploadFiles`)
+
+```tsx
+const { upload } = useUploadFiles({ route: 'images' });
+
+upload(files, {
+  metadata: { folder: 'profile-pics', userId: '123' },
+});
+```
+
+Validate this on the server with `clientMetadataSchema` in the route definition.
+
+---
+
+## `useUploadFile` — Single File
+
+```tsx
+import { useUploadFile } from '@better-upload/client';
+
+const {
+  upload,        // (file: File, options?) => void
+  uploadAsync,
+  reset,
+  control,
+
+  // state
+  uploadedFile,  // File | null
+  progress,      // number (0–1)
+  isPending,
+  isAborted,
+  isSettled,
+  isError,
+  isSuccess,
+  error,
+  metadata,      // object | null
+} = useUploadFile({
+  route: 'avatar',
+  api: '/api/upload',
+  // same options as useUploadFiles except uploadBatchSize
+});
+```
+
+### Events for `useUploadFile`
+
+```tsx
+useUploadFile({
+  route: 'avatar',
+
+  onBeforeUpload: ({ file }) => {
+    return new File([file], 'avatar.jpg', { type: file.type });
+  },
+
+  onUploadBegin: ({ file, metadata }) => {},
+  onUploadProgress: ({ file }) => { console.log(file.progress); },
+  onUploadComplete: ({ file, metadata }) => {},
+  onError: (error) => {},
+  onUploadSettle: ({ file, metadata }) => {},
+});
+```
+
+### Sending metadata (`useUploadFile`)
+
+```tsx
+upload(file, { metadata: { category: 'profile' } });
+```
+
+---
+
+## Imperative Functions (without hooks)
+
+Use these with TanStack Query's `useMutation` or any async context.
+
+### `uploadFiles`
+
+```tsx
+import { uploadFiles, type FileUploadInfo, type UploadStatus } from '@better-upload/client';
+
+const result = await uploadFiles({
+  files: Array.from(fileList),
+  route: 'images',
+  api: '/api/upload',       // optional
+  headers: {},              // optional
+  credentials: 'include',   // optional
+  signal: controller.signal, // optional
+  retry: 0,                 // optional
+  retryDelay: 0,            // optional
+
+  onFileStateChange: ({ file }) => {
+    // file is FileUploadInfo<UploadStatus>
+    // manually track progress with this callback
+    console.log(file);
+  },
+});
+
+// result: { files: File[], failedFiles: File[], metadata: object | null }
+```
+
+### `uploadFile`
+
+```tsx
+import { uploadFile } from '@better-upload/client';
+
+const result = await uploadFile({
+  file,
+  route: 'avatar',
+  onFileStateChange: ({ file }) => { console.log(file.progress); },
+});
+
+// result: { file: File, metadata: object | null }
+```
+
+---
+
+## Pre-built Components
+
+Better Upload provides optional shadcn-compatible UI components. Install via shadcn CLI:
+
+```bash
+npx shadcn@latest add @better-upload/upload-dropzone  # multiple files dropzone
+npx shadcn@latest add @better-upload/upload-button    # single file button
+npx shadcn@latest add @better-upload/upload-progress  # progress display
+npx shadcn@latest add @better-upload/paste-upload-area # paste-to-upload wrapper
+```
+
+Use the `control` property from the hook to connect:
+
+```tsx
+import { useUploadFiles } from '@better-upload/client';
+import { UploadDropzone } from '@/components/ui/upload-dropzone';
+
+export function Uploader() {
+  const { control } = useUploadFiles({ route: 'images' });
+
+  return (
+    <UploadDropzone
+      control={control}
+      accept="image/*"
+      description={{ maxFiles: 4, maxFileSize: '5MB', fileTypes: 'JPEG, PNG' }}
+    />
+  );
+}
+```

--- a/skills/better-upload/reference/helpers.md
+++ b/skills/better-upload/reference/helpers.md
@@ -1,0 +1,166 @@
+# Helpers Reference — `@better-upload/server` and `@better-upload/client`
+
+## Server Helpers — `@better-upload/server/helpers`
+
+All helpers accept an S3 client as the first argument (created via `@better-upload/server/clients`).
+
+### Pre-signed URLs
+
+```ts
+import { presignGetObject } from '@better-upload/server/helpers';
+
+// Generate a signed URL to let clients download an object
+const url = await presignGetObject(s3, {
+  bucket: 'my-bucket',
+  key: 'images/photo.jpg',
+  expiresIn: 3600, // seconds (1 hour)
+});
+```
+
+### Reading Objects
+
+```ts
+import { getObject, getObjectStream, headObject } from '@better-upload/server/helpers';
+
+// Get object as Blob
+const blob = await getObject(s3, { bucket: 'my-bucket', key: 'file.pdf' });
+
+// Get object as ReadableStream (for proxying large files)
+const stream = await getObjectStream(s3, { bucket: 'my-bucket', key: 'file.pdf' });
+
+// Get metadata only (no content download)
+const meta = await headObject(s3, { bucket: 'my-bucket', key: 'file.pdf' });
+// meta.contentType, meta.contentLength, meta.lastModified, etc.
+```
+
+### Listing Objects
+
+```ts
+import { listObjectsV2 } from '@better-upload/server/helpers';
+
+const { contents } = await listObjectsV2(s3, {
+  bucket: 'my-bucket',
+  prefix: 'users/123/',  // optional
+  maxKeys: 100,          // optional
+});
+```
+
+### Writing Objects
+
+```ts
+import { putObject } from '@better-upload/server/helpers';
+
+await putObject(s3, {
+  bucket: 'my-bucket',
+  key: 'exports/report.csv',
+  body: csvString,
+  contentType: 'text/csv',
+});
+```
+
+> Do not use `putObject` for client-side uploads or large files — use the router for that.
+
+### Deleting Objects
+
+```ts
+import { deleteObject, deleteObjects } from '@better-upload/server/helpers';
+
+// Single delete
+await deleteObject(s3, { bucket: 'my-bucket', key: 'old-file.png' });
+
+// Batch delete
+const { deleted, errors } = await deleteObjects(s3, {
+  bucket: 'my-bucket',
+  objects: [{ key: 'file1.png' }, { key: 'file2.png' }, { key: 'file3.png' }],
+});
+```
+
+### Moving and Copying Objects
+
+```ts
+import { moveObject, copyObject } from '@better-upload/server/helpers';
+
+// Move (copy + delete original — can be slow for large files)
+await moveObject(s3, {
+  source: { bucket: 'my-bucket', key: 'temp/upload.jpg' },
+  destination: { bucket: 'my-bucket', key: 'permanent/image.jpg' },
+});
+
+// Copy
+await copyObject(s3, {
+  source: { bucket: 'source-bucket', key: 'original.jpg' },
+  destination: { bucket: 'dest-bucket', key: 'copy/image.jpg' },
+});
+```
+
+### Object Tagging
+
+```ts
+import { getObjectTagging, putObjectTagging, deleteObjectTagging } from '@better-upload/server/helpers';
+
+const { tags, tagsObject } = await getObjectTagging(s3, { bucket: 'my-bucket', key: 'file.jpg' });
+
+await putObjectTagging(s3, {
+  bucket: 'my-bucket',
+  key: 'file.jpg',
+  tagging: { env: 'production', owner: 'user-123' },
+});
+
+await deleteObjectTagging(s3, { bucket: 'my-bucket', key: 'file.jpg' });
+```
+
+### Multipart Upload Helpers (low-level)
+
+For manually managing multipart uploads outside the router:
+
+```ts
+import {
+  createMultipartUpload,
+  uploadPart,
+  completeMultipartUpload,
+  abortMultipartUpload,
+} from '@better-upload/server/helpers';
+
+const { uploadId } = await createMultipartUpload(s3, {
+  bucket: 'my-bucket',
+  key: 'large-video.mp4',
+  contentType: 'video/mp4',
+});
+
+const { eTag } = await uploadPart(s3, {
+  bucket: 'my-bucket',
+  key: 'large-video.mp4',
+  uploadId,
+  partNumber: 1,
+  body: chunk, // Blob | Buffer | ArrayBuffer
+});
+
+await completeMultipartUpload(s3, {
+  bucket: 'my-bucket',
+  key: 'large-video.mp4',
+  uploadId,
+  parts: [{ partNumber: 1, eTag }],
+});
+
+// abort if something goes wrong
+await abortMultipartUpload(s3, { bucket: 'my-bucket', key: 'large-video.mp4', uploadId });
+```
+
+---
+
+## Client Helpers — `@better-upload/client/helpers`
+
+### `formatBytes`
+
+Format a raw byte count into a human-readable string.
+
+```ts
+import { formatBytes } from '@better-upload/client/helpers';
+
+formatBytes(1000);                                      // "1 kB"
+formatBytes(1000, { decimalPlaces: 2 });               // "1.00 kB"
+formatBytes(1024, { si: false });                       // "1 KiB"
+formatBytes(1024, { decimalPlaces: 2, si: false });    // "1.00 KiB"
+```
+
+Useful for displaying `maxFileSize` limits or current file sizes in the UI.

--- a/skills/better-upload/reference/server.md
+++ b/skills/better-upload/reference/server.md
@@ -1,0 +1,189 @@
+# Server Reference — `@better-upload/server`
+
+## Router
+
+The `Router` is the central configuration object. Pass it to an adapter to expose the upload endpoint.
+
+```ts
+import { type Router } from '@better-upload/server';
+
+export const router: Router = {
+  client: s3,           // S3-compatible client (see S3 Clients below)
+  bucketName: 'my-bucket',
+  routes: {
+    // named routes — name must match what the client sends
+    images: route({ multipleFiles: true, fileTypes: ['image/*'] }),
+    avatar: route({ fileTypes: ['image/*'], maxFileSize: 1024 * 1024 }),
+  },
+};
+```
+
+## Route Options
+
+Use the `route()` function to define each route.
+
+### Multiple files (`multipleFiles: true`)
+
+```ts
+import { route } from '@better-upload/server';
+
+route({
+  multipleFiles: true,
+  fileTypes: ['image/*', 'application/pdf'], // optional, all types allowed if omitted
+  maxFileSize: 1024 * 1024 * 5,            // 5MB, default
+  maxFiles: 3,                              // default
+  signedUrlExpiresIn: 120,                  // seconds, default
+  clientMetadataSchema: zodSchema,          // optional Standard Schema (Zod, etc.)
+});
+```
+
+### Single file (no `multipleFiles`)
+
+```ts
+route({
+  fileTypes: ['image/*'],
+  maxFileSize: 1024 * 1024 * 2, // 2MB
+  signedUrlExpiresIn: 120,
+  clientMetadataSchema: zodSchema,
+});
+```
+
+## Callbacks
+
+### `onBeforeUpload`
+
+Runs before pre-signed URLs are generated. Use for auth, rate-limiting, setting custom keys.
+
+```ts
+// Single file version
+route({
+  onBeforeUpload: async ({ req, file, clientMetadata }) => {
+    const user = await auth();
+    if (!user) throw new RejectUpload('Not logged in!');
+
+    return {
+      objectInfo: {             // object key and S3 options
+        key: `users/${user.id}/${file.name}`,
+        // acl, metadata, storageClass, cacheControl, tagging all optional
+      },
+      metadata: { userId: user.id }, // passed to onAfterSignedUrl
+      bucketName: 'another-bucket',  // override bucket if needed
+    };
+  },
+});
+
+// Multiple files version — uses generateObjectInfo per file
+route({
+  multipleFiles: true,
+  onBeforeUpload: async ({ req, files, clientMetadata }) => {
+    const user = await auth();
+    if (!user) throw new RejectUpload('Not authenticated');
+
+    const uploadId = crypto.randomUUID();
+    return {
+      generateObjectInfo: ({ file }) => ({
+        key: `uploads/${uploadId}/${file.name}`,
+        // skip: true  ← to skip a specific file
+      }),
+      metadata: { userId: user.id },
+    };
+  },
+});
+```
+
+**Important**: throw `RejectUpload` (imported from `@better-upload/server`) to reject and send the error to the client.
+
+### `onAfterSignedUrl`
+
+Runs after pre-signed URLs are generated. Use for logging, saving records.
+
+```ts
+// Single file
+route({
+  onAfterSignedUrl: async ({ req, file, metadata, clientMetadata }) => {
+    // file.objectInfo is now populated
+    await db.files.create({ key: file.objectInfo.key, userId: metadata.userId });
+
+    return {
+      metadata: { fileKey: file.objectInfo.key }, // sent back to client
+    };
+  },
+});
+
+// Multiple files
+route({
+  multipleFiles: true,
+  onAfterSignedUrl: async ({ req, files, metadata, clientMetadata }) => {
+    // files[n].objectInfo is populated
+    return { metadata: { count: files.length } };
+  },
+});
+```
+
+## Multipart Uploads
+
+For files larger than 5GB, or when you want faster uploads via parallel parts:
+
+```ts
+route({
+  multipart: true,
+  partSize: 1024 * 1024 * 50,           // 50MB per part (default)
+  partSignedUrlExpiresIn: 1500,          // 25 min (default)
+  completeSignedUrlExpiresIn: 1800,      // 30 min (default)
+  // combine with multipleFiles: true if needed
+});
+```
+
+No client-side changes needed — multipart is handled automatically.
+
+> Empty files (0 bytes) will fail with multipart. 
+> Even for files under 5GB, multipart can speed up uploads.
+
+## Adapters
+
+### Next.js App Router
+
+```ts title="app/api/upload/route.ts"
+import { toRouteHandler } from '@better-upload/server/adapters/next';
+export const { POST } = toRouteHandler(router);
+```
+
+### Node.js (raw Request/Response)
+
+```ts
+import { toNodeHandler } from '@better-upload/server/adapters/node';
+// toNodeHandler(router) returns a Node.js HTTP request handler
+```
+
+## S3 Clients
+
+All clients are exported from `@better-upload/server/clients`.
+All parameters are optional — if omitted, clients read from environment variables.
+
+| Client | Function | Key env vars |
+|---|---|---|
+| AWS S3 | `aws()` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| Cloudflare R2 | `cloudflare()` | `CLOUDFLARE_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
+| Backblaze B2 | `backblaze()` | `BACKBLAZE_KEY_ID`, `BACKBLAZE_APPLICATION_KEY`, `BACKBLAZE_REGION` |
+| DigitalOcean Spaces | `digitalocean()` | `DIGITALOCEAN_ACCESS_KEY_ID`, `DIGITALOCEAN_SECRET_ACCESS_KEY`, `DIGITALOCEAN_REGION` |
+| Linode / Akamai | `linode()` | `LINODE_ACCESS_KEY_ID`, `LINODE_SECRET_ACCESS_KEY`, `LINODE_REGION` |
+| MinIO | `minio()` | `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY_ID`, `MINIO_SECRET_ACCESS_KEY` |
+| Tigris | `tigris()` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
+| Wasabi | `wasabi()` | `WASABI_ACCESS_KEY_ID`, `WASABI_SECRET_ACCESS_KEY`, `WASABI_REGION` |
+| Custom | `custom({ host, accessKeyId, secretAccessKey, region })` | — |
+
+```ts
+import { cloudflare, aws, minio } from '@better-upload/server/clients';
+
+// Use env vars
+const s3 = cloudflare();
+
+// Or explicit params
+const s3 = aws({ accessKeyId: '...', secretAccessKey: '...', region: 'us-east-1' });
+```
+
+## Exports from `@better-upload/server`
+
+- `route(options)` — create a route definition
+- `type Router` — type for the router object
+- `RejectUpload` — error class to throw inside callbacks to reject uploads


### PR DESCRIPTION
Adds an installable Agent Skill package for `@better-upload/server` and `@better-upload/client`, enabling AI coding assistants to work more effectively with this library. Also updates the quickstart guide to surface the skill installation as an optional step.

## Docs update

### `apps/docs/content/docs/quickstart.mdx`
Added an optional final step — **"Install AI Agent Skills"** — pointing users of AI coding assistants (Claude Code, Cursor, OpenCode, Antigravity, etc.) to install the skill:

```bash
npx skills add Nic13Gamer/better-upload
```
<img width="1908" height="882" alt="FireShot Capture 183 - Quickstart - Better Upload -  localhost" src="https://github.com/user-attachments/assets/85b2269b-11ef-4687-85ab-07c0433b010f" />



## What's included

### `skills/better-upload/SKILL.md`
Main entry point. Contains a quick-start example (server router + client hook), the library architecture overview, and a linked index to all reference and example files. Follows the [Agent Skills specification](https://agentskills.io/specification) with a CSO-optimized description for accurate triggering.

### `skills/better-upload/reference/`
Technical reference files loaded on-demand by the agent — only what's needed for the current task:

- **`server.md`** — `route()` options, `onBeforeUpload`/`onAfterSignedUrl` callbacks, `RejectUpload`, multipart uploads, Next.js and Node.js adapters, all built-in S3 clients (AWS, Cloudflare R2, MinIO, Backblaze, DigitalOcean, Linode, Tigris, Wasabi)
- **`client.md`** — `useUploadFiles` and `useUploadFile` hooks (all options, state, and events), imperative `uploadFile`/`uploadFiles` functions, pre-built shadcn components (`UploadDropzone`, `UploadButton`, etc.)
- **`helpers.md`** — Server-side S3 helpers (`presignGetObject`, `getObject`, `deleteObject`, `moveObject`, `copyObject`, object tagging, multipart helpers) and client-side `formatBytes`

### `skills/better-upload/examples/`
Focused, copy-paste examples — one topic per file, each with a link back to the relevant reference:

- **`server-router.md`** — Full multi-route Next.js handler
- **`authentication.md`** — Auth guard with `RejectUpload` and per-user object keys
- **`single-file-upload.md`** — Avatar upload with fixed S3 key
- **`client-metadata.md`** — Sending metadata from client + Zod validation on server
- **`tanstack-query.md`** — Using `uploadFiles`/`uploadFile` with `useMutation`
- **`dropzone-component.md`** — `<UploadDropzone />` via shadcn CLI
- **`abort-upload.md`** — Cancelling an in-progress upload with `AbortController`
- **`delete-files.md`** — Deleting objects with the `deleteObject` helper
- **`cors-configuration.md`** — Required CORS policy for S3 buckets

## Installation

```bash
npx skills add Nic13Gamer/better-upload
# or
bunx skills add Nic13Gamer/better-upload
```
