### PR TITLE
feat: resumable multipart uploads

### DIFF
--- a/.changeset/resumable-multipart-uploads.md
+++ b/.changeset/resumable-multipart-uploads.md
@@ -1,0 +1,6 @@
+---
+'@better-upload/server': patch
+'@better-upload/client': patch
+---
+
+Add resume support for multipart uploads via `getResumeState` hook prop and `listParts` S3 helper

--- a/apps/docs/content/docs/helpers-server.mdx
+++ b/apps/docs/content/docs/helpers-server.mdx
@@ -249,6 +249,24 @@ await abortMultipartUpload(s3, {
 });
 ```
 
+#### List parts
+
+List the parts already uploaded for an in-progress multipart upload. Useful when implementing custom resume flows.
+
+A single call returns up to `maxParts` parts (1000 max, per the S3 API). Paginate by passing `partNumberMarker` from the previous `nextPartNumberMarker` until `isTruncated` is `false`.
+
+```ts
+import { listParts } from '@better-upload/server/helpers';
+
+const { parts, isTruncated, nextPartNumberMarker } = await listParts(s3, {
+  bucket: 'my-bucket',
+  key: 'large-file.zip',
+  uploadId: '...',
+  maxParts: 1000, // optional
+  partNumberMarker: undefined, // optional
+});
+```
+
 ### Object tagging operations
 
 Helpers for managing object tags in S3-compatible storage services.

--- a/apps/docs/content/docs/hooks-multiple.mdx
+++ b/apps/docs/content/docs/hooks-multiple.mdx
@@ -132,6 +132,12 @@ The `useUploadFiles` hook accepts the following options:
       default: '0',
       required: false,
     },
+    getResumeState: {
+      description:
+        'Resolve a persisted multipart upload state for each file so the server can resume the upload instead of starting a new one. Return undefined to start fresh. Only applies to multipart routes.',
+      type: '(file: File) => { uploadId: string; key: string } | undefined | Promise<...>',
+      required: false,
+    },
   }}
 />
 

--- a/apps/docs/content/docs/hooks-single.mdx
+++ b/apps/docs/content/docs/hooks-single.mdx
@@ -122,6 +122,12 @@ The `useUploadFile` hook accepts the following options:
       default: '0',
       required: false,
     },
+    getResumeState: {
+      description:
+        'Resolve a persisted multipart upload state for a file so the server can resume the upload instead of starting a new one. Return undefined to start fresh. Only applies to multipart routes.',
+      type: '(file: File) => { uploadId: string; key: string } | undefined | Promise<...>',
+      required: false,
+    },
   }}
 />
 

--- a/apps/docs/content/docs/routes-multiple.mdx
+++ b/apps/docs/content/docs/routes-multiple.mdx
@@ -227,6 +227,48 @@ You can now also modify the following options:
   process. Empty files (0 bytes) will fail to upload with multipart uploads.
 </Callout>
 
+### Resume
+
+A multipart upload can be resumed after a page reload or browser crash. The client persists the S3 `uploadId` and object `key`, then passes them back via the `getResumeState` hook prop on the next attempt. The server queries S3 [`ListParts`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html) and only signs URLs for the parts that are still missing.
+
+```tsx
+const { upload } = useUploadFile({
+  route: 'videos',
+  getResumeState: (file) => {
+    const raw = localStorage.getItem(`upload:${file.name}:${file.size}`);
+    return raw ? JSON.parse(raw) : undefined;
+  },
+  onUploadBegin: ({ file }) => {
+    if (file.uploadId) {
+      localStorage.setItem(
+        `upload:${file.name}:${file.size}`,
+        JSON.stringify({ uploadId: file.uploadId, key: file.objectInfo.key })
+      );
+    }
+  },
+  onUploadComplete: ({ file }) => {
+    localStorage.removeItem(`upload:${file.name}:${file.size}`);
+  },
+});
+```
+
+The `file.uploadId` is exposed on `FileUploadInfo` only for multipart routes. Persisting it (and the matching `key`) is the application's responsibility — `localStorage`, `IndexedDB`, or a database all work. Identify the file with whatever fingerprint suits your UX (`name + size + lastModified`, a content hash, etc.).
+
+If the persisted multipart upload no longer exists on S3 (lifecycle rule expiration or a manual abort), the server falls back to a fresh upload automatically — the client receives a new `uploadId` and starts from scratch.
+
+To reject a resume in `onBeforeUpload` (e.g. ensure the key belongs to the current user), inspect `file.resume`:
+
+```ts
+route({
+  multipart: true,
+  onBeforeUpload({ file }) {
+    if (file.resume && !file.resume.key.startsWith(`users/${userId}/`)) {
+      throw new RejectUpload('Cannot resume an upload that is not yours.');
+    }
+  },
+});
+```
+
 ## Router
 
 The router is where all upload routes are defined. To define a router, create an object with the `Router` type.

--- a/apps/docs/content/docs/routes-single.mdx
+++ b/apps/docs/content/docs/routes-single.mdx
@@ -113,7 +113,8 @@ You can return an object with the following properties:
       typeDescription: (
         <>
           Can return: <code>key</code>, <code>metadata</code>, <code>acl</code>,{' '}
-          <code>storageClass</code>, <code>cacheControl</code>, <code>tagging</code>.
+          <code>storageClass</code>, <code>cacheControl</code>,{' '}
+          <code>tagging</code>.
         </>
       ),
       required: false,

--- a/packages/client/src/hooks/use-upload-file.ts
+++ b/packages/client/src/hooks/use-upload-file.ts
@@ -29,6 +29,7 @@ export function useUploadFile(
     signal: props.signal,
     retry: props.retry,
     retryDelay: props.retryDelay,
+    getResumeState: props.getResumeState,
     onError: props.onError,
     onUploadProgress: props.onUploadProgress,
     onBeforeUpload: props.onBeforeUpload

--- a/packages/client/src/hooks/use-upload-files.ts
+++ b/packages/client/src/hooks/use-upload-files.ts
@@ -22,6 +22,7 @@ export function useUploadFiles({
   signal,
   retry,
   retryDelay,
+  getResumeState,
   onError,
   onBeforeUpload,
   onUploadBegin,
@@ -131,6 +132,7 @@ export function useUploadFiles({
           signal,
           retry,
           retryDelay,
+          getResumeState,
           onUploadBegin,
           onFileStateChange: ({ file }) => {
             setUploads((prev) => new Map(prev).set(file.objectInfo.key, file));

--- a/packages/client/src/types/internal.ts
+++ b/packages/client/src/types/internal.ts
@@ -29,6 +29,15 @@ export type SignedUrlsSuccessResponse = {
             partNumber: number;
             size: number;
           }[];
+          /**
+           * Parts already uploaded to S3 (populated on resume).
+           * Their ETags are merged into the final CompleteMultipartUpload call.
+           */
+          completedParts?: {
+            partNumber: number;
+            eTag: string;
+            size: number;
+          }[];
           uploadId: string;
           completeSignedUrl: string;
           abortSignedUrl: string;
@@ -176,6 +185,20 @@ export type UploadHookProps<T extends boolean> = {
    * @default 0
    */
   retryDelay?: number;
+
+  /**
+   * Resolve a persisted multipart upload state for a file so the server can
+   * resume the upload instead of starting a new one. Return `undefined` to
+   * start fresh.
+   *
+   * **Only applies to multipart routes.**
+   */
+  getResumeState?: (
+    file: File
+  ) =>
+    | { uploadId: string; key: string }
+    | undefined
+    | Promise<{ uploadId: string; key: string } | undefined>;
 } & (T extends true
   ? {
       /**

--- a/packages/client/src/types/public.ts
+++ b/packages/client/src/types/public.ts
@@ -82,6 +82,14 @@ export type FileUploadInfo<T extends UploadStatus> = {
    * If the upload was skipped because the server indicated it was already completed.
    */
   skip: 'completed' | undefined;
+
+  /**
+   * The S3 multipart upload id, only set for multipart uploads.
+   *
+   * Persist this (paired with `objectInfo.key`) to resume the upload via
+   * `getResumeState` if the page reloads or the browser crashes.
+   */
+  uploadId?: string;
 } & (T extends 'failed'
   ? {
       error: ClientUploadError;

--- a/packages/client/src/utils/internal/s3-upload.ts
+++ b/packages/client/src/utils/internal/s3-upload.ts
@@ -75,6 +75,7 @@ export async function uploadFileToS3(params: {
 export async function uploadMultipartFileToS3(params: {
   file: File;
   parts: { signedUrl: string; partNumber: number; size: number }[];
+  completedParts?: { partNumber: number; eTag: string; size: number }[];
   partSize: number;
   uploadId: string;
   completeSignedUrl: string;
@@ -84,8 +85,15 @@ export async function uploadMultipartFileToS3(params: {
   retry?: number;
   retryDelay?: number;
 }) {
-  const uploadedParts: { etag: string; number: number }[] = [];
+  const completedPartCount = params.completedParts?.length || 0;
+  const uploadedParts: { etag: string; number: number }[] = (
+    params.completedParts || []
+  ).map((part) => ({
+    etag: part.eTag.replace(/"/g, ''),
+    number: part.partNumber,
+  }));
   const progresses: { [part: number]: number } = {};
+  const totalPartCount = params.parts.length + completedPartCount;
 
   const uploadPromises = params.parts.map((part) => async () => {
     const xhr = new XMLHttpRequest();
@@ -124,9 +132,12 @@ export async function uploadMultipartFileToS3(params: {
             if (event.lengthComputable) {
               progresses[part.partNumber] = event.loaded / event.total;
 
+              const liveSum = Object.values(progresses).reduce(
+                (acc, curr) => acc + curr,
+                0
+              );
               const totalProgress =
-                Object.values(progresses).reduce((acc, curr) => acc + curr, 0) /
-                params.parts.length;
+                (liveSum + completedPartCount) / totalPartCount;
 
               params.onProgress?.(Math.min(totalProgress, 0.99));
             }

--- a/packages/client/src/utils/upload.ts
+++ b/packages/client/src/utils/upload.ts
@@ -26,6 +26,20 @@ export async function uploadFiles(params: {
   retry?: number;
   retryDelay?: number;
 
+  /**
+   * Resolve a persisted multipart upload state for a file so the server can
+   * resume the upload instead of starting a new one. Return `undefined` to
+   * start fresh.
+   *
+   * **Only applies to multipart routes.**
+   */
+  getResumeState?: (
+    file: File
+  ) =>
+    | { uploadId: string; key: string }
+    | undefined
+    | Promise<{ uploadId: string; key: string } | undefined>;
+
   onUploadBegin?: (data: {
     files: FileUploadInfo<'pending'>[];
     metadata: ServerMetadata;
@@ -45,6 +59,10 @@ export async function uploadFiles(params: {
     const headers = new Headers(params.headers);
     headers.set('Content-Type', 'application/json');
 
+    const resumeStates = params.getResumeState
+      ? await Promise.all(files.map((file) => params.getResumeState!(file)))
+      : files.map(() => undefined);
+
     const signedUrlRes = await withRetries(
       () =>
         fetch(params.api || '/api/upload', {
@@ -52,10 +70,11 @@ export async function uploadFiles(params: {
           body: JSON.stringify({
             route: params.route,
             metadata: params.metadata,
-            files: files.map((file) => ({
+            files: files.map((file, index) => ({
               name: file.name,
               size: file.size,
               type: file.type,
+              ...(resumeStates[index] ? { resume: resumeStates[index] } : {}),
             })),
           }),
           headers,
@@ -102,6 +121,7 @@ export async function uploadFiles(params: {
               file.size === url.file.size &&
               file.type === url.file.type
           )!,
+          uploadId: 'uploadId' in url ? url.uploadId : undefined,
           ...url.file,
         },
       ])
@@ -136,6 +156,7 @@ export async function uploadFiles(params: {
           await uploadMultipartFileToS3({
             file,
             parts: url.parts,
+            completedParts: url.completedParts,
             partSize,
             uploadId: url.uploadId,
             completeSignedUrl: url.completeSignedUrl,
@@ -274,6 +295,19 @@ export async function uploadFile(params: {
   retry?: number;
   retryDelay?: number;
 
+  /**
+   * Resolve a persisted multipart upload state so the server can resume the
+   * upload instead of starting a new one. Return `undefined` to start fresh.
+   *
+   * **Only applies to multipart routes.**
+   */
+  getResumeState?: (
+    file: File
+  ) =>
+    | { uploadId: string; key: string }
+    | undefined
+    | Promise<{ uploadId: string; key: string } | undefined>;
+
   onUploadBegin?: (data: {
     file: FileUploadInfo<'pending'>;
     metadata: ServerMetadata;
@@ -291,6 +325,7 @@ export async function uploadFile(params: {
     credentials: params.credentials,
     retry: params.retry,
     retryDelay: params.retryDelay,
+    getResumeState: params.getResumeState,
     onUploadBegin: (data) => {
       params.onUploadBegin?.({
         file: data.files[0]!,

--- a/packages/server/src/helpers/index.ts
+++ b/packages/server/src/helpers/index.ts
@@ -13,6 +13,7 @@ export * from './s3/put-object-tagging';
 export * from './s3/abort-multipart-upload';
 export * from './s3/complete-multipart-upload';
 export * from './s3/create-multipart-upload';
+export * from './s3/list-parts';
 export * from './s3/upload-part';
 
 export * from './s3/presign/get-object';

--- a/packages/server/src/helpers/s3/list-parts.ts
+++ b/packages/server/src/helpers/s3/list-parts.ts
@@ -1,0 +1,78 @@
+import type { Client } from '@/types/clients';
+import { throwS3Error } from '@/utils/s3';
+import { parseXml } from '@/utils/xml';
+
+/**
+ * List the parts already uploaded for an in-progress multipart upload.
+ */
+export async function listParts(
+  client: Client,
+  params: {
+    bucket: string;
+    key: string;
+    uploadId: string;
+    maxParts?: number;
+    partNumberMarker?: number;
+  }
+) {
+  if (!params.key.trim()) {
+    throw new Error('The object key cannot be empty.');
+  }
+
+  const url = new URL(`${client.buildBucketUrl(params.bucket)}/${params.key}`);
+  url.searchParams.set('uploadId', params.uploadId);
+
+  if (params.maxParts) {
+    url.searchParams.set('max-parts', params.maxParts.toString());
+  }
+  if (params.partNumberMarker) {
+    url.searchParams.set(
+      'part-number-marker',
+      params.partNumberMarker.toString()
+    );
+  }
+
+  const res = await throwS3Error(
+    client.s3.fetch(url.toString(), {
+      method: 'GET',
+      aws: { signQuery: true, allHeaders: true },
+    })
+  );
+
+  const parsed = parseXml<{
+    ListPartsResult: {
+      Bucket: string;
+      Key: string;
+      UploadId: string;
+      PartNumberMarker?: number;
+      NextPartNumberMarker?: number;
+      MaxParts: number;
+      IsTruncated: boolean;
+      Part?: {
+        PartNumber: number;
+        ETag: string;
+        Size: number;
+        LastModified: string;
+      }[];
+    };
+  }>(await res.text(), {
+    arrayPath: ['ListPartsResult.Part'],
+  });
+
+  return {
+    bucket: parsed.ListPartsResult.Bucket,
+    key: parsed.ListPartsResult.Key,
+    uploadId: parsed.ListPartsResult.UploadId,
+    partNumberMarker: parsed.ListPartsResult.PartNumberMarker,
+    nextPartNumberMarker: parsed.ListPartsResult.NextPartNumberMarker,
+    maxParts: parsed.ListPartsResult.MaxParts,
+    isTruncated: parsed.ListPartsResult.IsTruncated,
+    parts:
+      parsed.ListPartsResult.Part?.map((item) => ({
+        partNumber: item.PartNumber,
+        eTag: item.ETag,
+        size: item.Size,
+        lastModified: new Date(item.LastModified),
+      })) || [],
+  };
+}

--- a/packages/server/src/helpers/s3/put-object.ts
+++ b/packages/server/src/helpers/s3/put-object.ts
@@ -27,7 +27,8 @@ export async function putObject(
     tagging?: Tagging;
   }
 ) {
-  const contentLength = params.contentLength ?? getBodyContentLength(params.body);
+  const contentLength =
+    params.contentLength ?? getBodyContentLength(params.body);
 
   await throwS3Error(
     client.s3.fetch(`${client.buildBucketUrl(params.bucket)}/${params.key}`, {

--- a/packages/server/src/router/handlers/multipart-handler.ts
+++ b/packages/server/src/router/handlers/multipart-handler.ts
@@ -1,4 +1,6 @@
 import { config } from '@/config';
+import { S3Error } from '@/error';
+import { listParts } from '@/helpers/s3/list-parts';
 import type { Client } from '@/types/clients';
 import type { Route } from '@/types/router/internal';
 import type { ObjectMetadata } from '@/types/s3';
@@ -113,7 +115,11 @@ export async function handleMultipartFiles({
           objectTagging,
           skip = undefined;
 
-        if (generateObjectInfoCallback) {
+        const resume = file.resume;
+
+        if (resume) {
+          objectKey = resume.key;
+        } else if (generateObjectInfoCallback) {
           const objectInfo = await generateObjectInfoCallback({ file });
 
           if (objectInfo.key) {
@@ -158,7 +164,7 @@ export async function handleMultipartFiles({
           };
         }
 
-        const { uploadId: s3UploadId } = await createMultipartUpload(client, {
+        const createParams = {
           bucket: bucketName,
           key: objectKey,
           contentType: file.type,
@@ -167,30 +173,81 @@ export async function handleMultipartFiles({
           storageClass: objectStorageClass,
           cacheControl: objectCacheControl,
           tagging: objectTagging,
-        });
+        };
+
+        let s3UploadId: string;
+        const completedPartsMap = new Map<
+          number,
+          { partNumber: number; eTag: string; size: number }
+        >();
+
+        if (resume) {
+          s3UploadId = resume.uploadId;
+          try {
+            let partNumberMarker: number | undefined;
+            do {
+              const page = await listParts(client, {
+                bucket: bucketName,
+                key: objectKey,
+                uploadId: s3UploadId,
+                partNumberMarker,
+              });
+              for (const part of page.parts) {
+                completedPartsMap.set(part.partNumber, {
+                  partNumber: part.partNumber,
+                  eTag: part.eTag,
+                  size: part.size,
+                });
+              }
+              partNumberMarker = page.isTruncated
+                ? page.nextPartNumberMarker
+                : undefined;
+            } while (partNumberMarker);
+          } catch (error) {
+            if (
+              error instanceof S3Error &&
+              error.message.includes('NoSuchUpload')
+            ) {
+              // The multipart upload expired or was aborted on S3. Start fresh.
+              completedPartsMap.clear();
+              s3UploadId = (await createMultipartUpload(client, createParams))
+                .uploadId;
+            } else {
+              throw error;
+            }
+          }
+        } else {
+          s3UploadId = (await createMultipartUpload(client, createParams))
+            .uploadId;
+        }
 
         const totalParts = Math.ceil(file.size / partSize);
 
-        const partSignedUrls = await Promise.all(
-          Array.from({ length: totalParts }, async (_, index) => {
-            const size = Math.min(partSize, file.size - index * partSize);
+        const partSignedUrls = (
+          await Promise.all(
+            Array.from({ length: totalParts }, async (_, index) => {
+              const partNumber = index + 1;
+              if (completedPartsMap.has(partNumber)) return null;
 
-            const url = await signUploadPart(client, {
-              bucket: bucketName,
-              key: objectKey,
-              uploadId: s3UploadId,
-              partNumber: index + 1,
-              contentLength: size,
-              expiresIn: partSignedUrlExpiresIn,
-            });
+              const size = Math.min(partSize, file.size - index * partSize);
 
-            return {
-              signedUrl: url,
-              partNumber: index + 1,
-              size,
-            };
-          })
-        );
+              const url = await signUploadPart(client, {
+                bucket: bucketName,
+                key: objectKey,
+                uploadId: s3UploadId,
+                partNumber,
+                contentLength: size,
+                expiresIn: partSignedUrlExpiresIn,
+              });
+
+              return {
+                signedUrl: url,
+                partNumber,
+                size,
+              };
+            })
+          )
+        ).filter((p) => p !== null);
 
         const [completeSignedUrl, abortSignedUrl] = await Promise.all([
           signCompleteMultipartUpload(client, {
@@ -220,6 +277,13 @@ export async function handleMultipartFiles({
             },
           },
           parts: partSignedUrls,
+          ...(completedPartsMap.size > 0
+            ? {
+                completedParts: Array.from(completedPartsMap.values()).sort(
+                  (a, b) => a.partNumber - b.partNumber
+                ),
+              }
+            : {}),
           uploadId: s3UploadId!,
           completeSignedUrl,
           abortSignedUrl,

--- a/packages/server/src/types/router/internal.ts
+++ b/packages/server/src/types/router/internal.ts
@@ -21,6 +21,18 @@ export type FileInfo<T extends boolean> = {
    * The MIME type of the file.
    */
   type: string;
+
+  /**
+   * If the client is asking to resume a previous multipart upload, the
+   * `uploadId` and `key` it persisted. Only ever present on multipart routes.
+   *
+   * Use this in `onBeforeUpload` to validate (e.g. ensure the key belongs to
+   * the current user) — throw `RejectUpload` to refuse the resume.
+   */
+  resume?: {
+    uploadId: string;
+    key: string;
+  };
 } & (T extends true
   ? {
       /**

--- a/packages/server/src/validations.ts
+++ b/packages/server/src/validations.ts
@@ -8,6 +8,12 @@ export const uploadFileSchema = z.object({
         name: z.string().check(z.minLength(1)),
         size: z.union([z.literal(0), z.int().check(z.positive())]),
         type: z.string(),
+        resume: z.optional(
+          z.object({
+            uploadId: z.string().check(z.minLength(1)),
+            key: z.string().check(z.minLength(1)),
+          })
+        ),
       })
     )
     .check(z.minLength(1)),

--- a/packages/server/test/list-parts.test.ts
+++ b/packages/server/test/list-parts.test.ts
@@ -1,0 +1,129 @@
+import { listParts } from '@/helpers/s3/list-parts';
+import type { Client } from '@/types/clients';
+import { describe, expect, it, vi } from 'vitest';
+
+const buildClient = (xml: string): Client =>
+  ({
+    buildBucketUrl: (bucket: string) => `https://${bucket}.s3.amazonaws.com`,
+    s3: {
+      fetch: vi.fn(async () => new Response(xml, { status: 200 })),
+    },
+  }) as unknown as Client;
+
+const xml = (parts: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<ListPartsResult>
+  <Bucket>my-bucket</Bucket>
+  <Key>uploads/big.mp4</Key>
+  <UploadId>upload-id-abc</UploadId>
+  <PartNumberMarker>0</PartNumberMarker>
+  <NextPartNumberMarker>2</NextPartNumberMarker>
+  <MaxParts>1000</MaxParts>
+  <IsTruncated>false</IsTruncated>
+  ${parts}
+</ListPartsResult>`;
+
+describe('listParts', () => {
+  it('parses a response with multiple parts', async () => {
+    const client = buildClient(
+      xml(`
+      <Part>
+        <PartNumber>1</PartNumber>
+        <ETag>"etag-1"</ETag>
+        <Size>5242880</Size>
+        <LastModified>2024-01-01T00:00:00.000Z</LastModified>
+      </Part>
+      <Part>
+        <PartNumber>2</PartNumber>
+        <ETag>"etag-2"</ETag>
+        <Size>5242880</Size>
+        <LastModified>2024-01-01T00:00:01.000Z</LastModified>
+      </Part>
+    `)
+    );
+
+    const result = await listParts(client, {
+      bucket: 'my-bucket',
+      key: 'uploads/big.mp4',
+      uploadId: 'upload-id-abc',
+    });
+
+    expect(result.bucket).toBe('my-bucket');
+    expect(result.key).toBe('uploads/big.mp4');
+    expect(result.uploadId).toBe('upload-id-abc');
+    expect(result.isTruncated).toBe(false);
+    expect(result.parts).toEqual([
+      {
+        partNumber: 1,
+        eTag: '"etag-1"',
+        size: 5242880,
+        lastModified: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      {
+        partNumber: 2,
+        eTag: '"etag-2"',
+        size: 5242880,
+        lastModified: new Date('2024-01-01T00:00:01.000Z'),
+      },
+    ]);
+  });
+
+  it('parses a single-part response (XML returns object, not array)', async () => {
+    const client = buildClient(
+      xml(`
+      <Part>
+        <PartNumber>1</PartNumber>
+        <ETag>"only-etag"</ETag>
+        <Size>1024</Size>
+        <LastModified>2024-01-01T00:00:00.000Z</LastModified>
+      </Part>
+    `)
+    );
+
+    const result = await listParts(client, {
+      bucket: 'my-bucket',
+      key: 'uploads/big.mp4',
+      uploadId: 'upload-id-abc',
+    });
+
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]?.partNumber).toBe(1);
+    expect(result.parts[0]?.eTag).toBe('"only-etag"');
+  });
+
+  it('parses an empty response (no parts uploaded yet)', async () => {
+    const client = buildClient(xml(''));
+
+    const result = await listParts(client, {
+      bucket: 'my-bucket',
+      key: 'uploads/big.mp4',
+      uploadId: 'upload-id-abc',
+    });
+
+    expect(result.parts).toEqual([]);
+  });
+
+  it('passes pagination params to S3', async () => {
+    const client = buildClient(xml(''));
+
+    await listParts(client, {
+      bucket: 'my-bucket',
+      key: 'uploads/big.mp4',
+      uploadId: 'upload-id-abc',
+      maxParts: 500,
+      partNumberMarker: 100,
+    });
+
+    const fetchMock = client.s3.fetch as ReturnType<typeof vi.fn>;
+    const calledUrl = new URL(fetchMock.mock.calls[0]?.[0]);
+    expect(calledUrl.searchParams.get('uploadId')).toBe('upload-id-abc');
+    expect(calledUrl.searchParams.get('max-parts')).toBe('500');
+    expect(calledUrl.searchParams.get('part-number-marker')).toBe('100');
+  });
+
+  it('throws when key is empty', async () => {
+    const client = buildClient(xml(''));
+    await expect(
+      listParts(client, { bucket: 'my-bucket', key: '', uploadId: 'x' })
+    ).rejects.toThrow('The object key cannot be empty.');
+  });
+});

--- a/packages/server/test/router.test.ts
+++ b/packages/server/test/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/mini';
 import {
   createTestRouter,
@@ -13,7 +13,23 @@ vi.mock('@/utils/s3', async (importOriginal) => ({
   })),
 }));
 
+vi.mock('@/helpers/s3/list-parts', () => ({
+  listParts: vi.fn(async () => ({
+    bucket: 'my-default-bucket',
+    key: 'mock-key',
+    uploadId: 'mock-upload-id',
+    partNumberMarker: undefined,
+    nextPartNumberMarker: undefined,
+    maxParts: 1000,
+    isTruncated: false,
+    parts: [],
+  })),
+}));
+
+import { S3Error } from '@/error';
+import { listParts } from '@/helpers/s3/list-parts';
 import { handleRequest, RejectUpload, route } from '@/router';
+import { createMultipartUpload } from '@/utils/s3';
 
 describe('request handler', () => {
   const { router } = createTestRouter({
@@ -600,5 +616,262 @@ describe('multipart handler', () => {
       file.abortSignedUrl = 'abort-signed-url-placeholder';
     });
     expect(json).toMatchSnapshot();
+  });
+});
+
+describe('multipart resume', () => {
+  const partSize = 1024 * 1024 * 50; // 50MB, matches default
+  const fileSize = partSize * 4; // 4 parts total
+
+  const { router } = createTestRouter({
+    routes: {
+      videos: route({
+        multipart: true,
+        maxFileSize: fileSize * 2,
+        onBeforeUpload({ file }) {
+          return {
+            objectInfo: { key: `videos/${file.name}` },
+          };
+        },
+      }),
+    },
+  });
+
+  beforeEach(() => {
+    vi.mocked(createMultipartUpload).mockClear();
+    vi.mocked(listParts).mockReset();
+    vi.mocked(listParts).mockResolvedValue({
+      bucket: 'my-default-bucket',
+      key: 'videos/file.mp4',
+      uploadId: 'existing-upload-id',
+      partNumberMarker: undefined,
+      nextPartNumberMarker: undefined,
+      maxParts: 1000,
+      isTruncated: false,
+      parts: [],
+    });
+  });
+
+  it('reuses uploadId and key from request, skips createMultipartUpload', async () => {
+    vi.mocked(listParts).mockResolvedValueOnce({
+      bucket: 'my-default-bucket',
+      key: 'videos/file.mp4',
+      uploadId: 'existing-upload-id',
+      partNumberMarker: undefined,
+      nextPartNumberMarker: undefined,
+      maxParts: 1000,
+      isTruncated: false,
+      parts: [
+        {
+          partNumber: 1,
+          eTag: '"etag-1"',
+          size: partSize,
+          lastModified: new Date(),
+        },
+        {
+          partNumber: 2,
+          eTag: '"etag-2"',
+          size: partSize,
+          lastModified: new Date(),
+        },
+      ],
+    });
+
+    const res = await handleRequest(
+      routerRequest({
+        method: 'POST',
+        body: routerUploadBody({
+          route: 'videos',
+          files: [
+            {
+              name: 'file.mp4',
+              size: fileSize,
+              type: 'video/mp4',
+              resume: {
+                uploadId: 'existing-upload-id',
+                key: 'videos/file.mp4',
+              },
+            },
+          ],
+        }),
+      }),
+      router
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(createMultipartUpload).not.toHaveBeenCalled();
+    expect(listParts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        uploadId: 'existing-upload-id',
+        key: 'videos/file.mp4',
+      })
+    );
+
+    const file = json.multipart.files[0];
+    expect(file.uploadId).toBe('existing-upload-id');
+    expect(file.file.objectInfo.key).toBe('videos/file.mp4');
+    expect(file.parts.map((p: any) => p.partNumber)).toEqual([3, 4]);
+    expect(file.completedParts).toEqual([
+      { partNumber: 1, eTag: '"etag-1"', size: partSize },
+      { partNumber: 2, eTag: '"etag-2"', size: partSize },
+    ]);
+  });
+
+  it('non-resume request still calls createMultipartUpload, omits completedParts work', async () => {
+    const res = await handleRequest(
+      routerRequest({
+        method: 'POST',
+        body: routerUploadBody({
+          route: 'videos',
+          files: [{ name: 'fresh.mp4', size: fileSize, type: 'video/mp4' }],
+        }),
+      }),
+      router
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(createMultipartUpload).toHaveBeenCalledOnce();
+    expect(listParts).not.toHaveBeenCalled();
+
+    const file = json.multipart.files[0];
+    expect(file.uploadId).toBe('mock-upload-id');
+    expect(file.parts.map((p: any) => p.partNumber)).toEqual([1, 2, 3, 4]);
+    expect(file.completedParts).toBeUndefined();
+  });
+
+  it('falls back to a fresh upload when listParts returns NoSuchUpload', async () => {
+    vi.mocked(listParts).mockRejectedValueOnce(
+      new S3Error('NoSuchUpload - The specified upload does not exist.')
+    );
+
+    const res = await handleRequest(
+      routerRequest({
+        method: 'POST',
+        body: routerUploadBody({
+          route: 'videos',
+          files: [
+            {
+              name: 'file.mp4',
+              size: fileSize,
+              type: 'video/mp4',
+              resume: {
+                uploadId: 'expired-upload-id',
+                key: 'videos/file.mp4',
+              },
+            },
+          ],
+        }),
+      }),
+      router
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(createMultipartUpload).toHaveBeenCalledOnce();
+
+    const file = json.multipart.files[0];
+    expect(file.uploadId).toBe('mock-upload-id');
+    expect(file.file.objectInfo.key).toBe('videos/file.mp4');
+    expect(file.parts.map((p: any) => p.partNumber)).toEqual([1, 2, 3, 4]);
+    expect(file.completedParts).toBeUndefined();
+  });
+
+  it('rethrows non-NoSuchUpload S3 errors from listParts', async () => {
+    vi.mocked(listParts).mockRejectedValueOnce(
+      new S3Error('AccessDenied - Permission denied.')
+    );
+
+    await expect(
+      handleRequest(
+        routerRequest({
+          method: 'POST',
+          body: routerUploadBody({
+            route: 'videos',
+            files: [
+              {
+                name: 'file.mp4',
+                size: fileSize,
+                type: 'video/mp4',
+                resume: {
+                  uploadId: 'some-upload-id',
+                  key: 'videos/file.mp4',
+                },
+              },
+            ],
+          }),
+        }),
+        router
+      )
+    ).rejects.toThrow('AccessDenied');
+  });
+
+  it('paginates listParts when isTruncated', async () => {
+    vi.mocked(listParts)
+      .mockResolvedValueOnce({
+        bucket: 'my-default-bucket',
+        key: 'videos/file.mp4',
+        uploadId: 'existing-upload-id',
+        partNumberMarker: undefined,
+        nextPartNumberMarker: 1,
+        maxParts: 1,
+        isTruncated: true,
+        parts: [
+          {
+            partNumber: 1,
+            eTag: '"etag-1"',
+            size: partSize,
+            lastModified: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        bucket: 'my-default-bucket',
+        key: 'videos/file.mp4',
+        uploadId: 'existing-upload-id',
+        partNumberMarker: 1,
+        nextPartNumberMarker: undefined,
+        maxParts: 1,
+        isTruncated: false,
+        parts: [
+          {
+            partNumber: 2,
+            eTag: '"etag-2"',
+            size: partSize,
+            lastModified: new Date(),
+          },
+        ],
+      });
+
+    const res = await handleRequest(
+      routerRequest({
+        method: 'POST',
+        body: routerUploadBody({
+          route: 'videos',
+          files: [
+            {
+              name: 'file.mp4',
+              size: fileSize,
+              type: 'video/mp4',
+              resume: {
+                uploadId: 'existing-upload-id',
+                key: 'videos/file.mp4',
+              },
+            },
+          ],
+        }),
+      }),
+      router
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(listParts).toHaveBeenCalledTimes(2);
+
+    const file = json.multipart.files[0];
+    expect(file.parts.map((p: any) => p.partNumber)).toEqual([3, 4]);
+    expect(file.completedParts.map((p: any) => p.partNumber)).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary

Adds the ability to resume an interrupted multipart upload after a page reload or browser crash. The S3 multipart `uploadId` already supports this natively; this PR exposes it through the existing client hooks and server route handler so apps can plug in their own persistence (localStorage, IndexedDB, DB, etc.).

## Server

- New [`listParts`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html) helper (`@better-upload/server/helpers`) — single-page, caller paginates (matches `listObjectsV2` shape).
- Multipart route handler accepts an optional `resume: { uploadId, key }` per file. When present, it skips `CreateMultipartUpload`, calls `ListParts`, signs URLs only for the missing parts, and returns the existing parts as `completedParts` in the response.
- If S3 returns `NoSuchUpload` (the multipart expired), the server transparently falls back to a fresh upload — clients get a new `uploadId` and start over.
- `resume` is surfaced on `FileInfo` inside `onBeforeUpload`, so apps can validate it (e.g. enforce key ownership) and `RejectUpload` if needed.

## Client

- New `getResumeState?: (file: File) => { uploadId, key } | undefined | Promise<...>` prop on `useUploadFile` / `useUploadFiles` and the `uploadFile` / `uploadFiles` utilities.
- `uploadId` is now exposed on `FileUploadInfo` (multipart only) so apps can persist it from `onUploadBegin`.
- Progress reporting accounts for parts already uploaded server-side, so a resumed upload starts at the correct percentage instead of 0%.

## Tests

- `listParts` unit tests covering multi-part, single-part (XML quirk), empty, pagination, and key-validation cases.
- Multipart handler integration tests covering the resume branch (reuse `uploadId`, skip `CreateMultipartUpload`), pagination across `listParts` pages, the `NoSuchUpload` fallback, and that non-resume requests are unchanged.

## Docs

- New "Resume" subsection under Multipart in `routes-multiple.mdx` with usage example + `onBeforeUpload` validation note.
- `helpers-server.mdx` entry for `listParts`.
- `getResumeState` added to props tables in `hooks-single.mdx` / `hooks-multiple.mdx`.

## Notes

- Backwards compatible — `completedParts` is only emitted when populated, so fresh-upload responses are unchanged.
- The application owns persistence and file identification (matching by name+size+lastModified, content hash, etc.) — the lib only provides the primitive.
